### PR TITLE
[Docs] Documentation d'installation et d'utilisation du plugin (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,26 @@ Plugin Claude Code pour le workflow AI-Driven Development. Fournit un pipeline c
 
 ## Installation
 
-### Test local
+### 1. Cloner le repo
 
 ```bash
-claude --plugin-dir /chemin/vers/claude-workflow
+git clone git@github.com:ToolsForSaaS/claude-workflow.git
 ```
 
-### Installation projet
+### 2. Ajouter le plugin
 
-Ajouter dans `.claude/settings.json` du projet cible :
+Dans `.claude/settings.json` du projet cible :
 
 ```json
 {
   "plugins": ["/chemin/vers/claude-workflow"]
 }
+```
+
+Ou pour tester sur une session :
+
+```bash
+claude --plugin-dir /chemin/vers/claude-workflow
 ```
 
 Les skills sont accessibles avec le namespace `workflow:` (ex: `/workflow:pipe-code`).


### PR DESCRIPTION
## Contexte

Closes #6

Le README etait completement obsolete (references a sync.sh, ancienne structure .claude/skills/, anciens noms de skills).

## Changements

Reecriture complete du README avec :
- Instructions d'installation (test local + projet)
- Pipeline et demarrage rapide
- Liste des 19 skills organisee par categorie (pipe, setup, create, audit, conventions)
- Structure du plugin
- Documentation des fichiers projet-specifiques
- Guide de migration depuis sync.sh

## Test plan

- [ ] Le README est lisible et coherent avec la structure actuelle du repo
- [ ] Les noms de skills correspondent aux repertoires dans skills/
- [ ] Les instructions d'installation sont correctes