### PR TITLE
[Fix] Rendre explicite la sequence git de creation de branche dans pipe-code

### DIFF
--- a/skills/pipe-code/SKILL.md
+++ b/skills/pipe-code/SKILL.md
@@ -33,7 +33,19 @@ Si une verification echoue, signale-le clairement et arrete-toi. Ne tente pas de
 
 ## Etape 1 — Creer la branche
 
-Utilise Read pour charger `${CLAUDE_SKILL_DIR}/../git-conventions/SKILL.md` pour les conventions de branches et commits, puis cree une branche depuis la **branche par defaut** definie dans `tech-stack` (section Git) en suivant la convention.
+Utilise Read pour charger `${CLAUDE_SKILL_DIR}/../git-conventions/SKILL.md` pour les conventions de branches et commits.
+
+Identifie la branche par defaut depuis le skill `tech-stack` (deja lu a l'etape 0, section Git, champ "Branche par defaut"). Stocke-la mentalement comme `BASE_BRANCH`.
+
+Execute exactement cette sequence :
+
+1. `git checkout <BASE_BRANCH>`
+2. `git pull origin <BASE_BRANCH>`
+3. `git checkout -b <nouvelle-branche>`
+
+Ou `<nouvelle-branche>` suit la convention definie dans `git-conventions`.
+
+Ne jamais hardcoder `main` ou `develop` — toujours lire la valeur depuis `tech-stack`.
 
 Annonce la branche creee avant de commencer.
 


### PR DESCRIPTION
## Contexte

L'etape 1 du skill pipe-code donne une instruction trop vague pour la creation de branche ("cree une branche depuis la branche par defaut"). L'agent LLM interprete ca comme `git checkout main` en dur, ignorant la valeur configuree dans tech-stack.

## Ce qui a ete fait

Remplacement de l'instruction floue par une sequence prescriptive explicite :
1. Lire la branche par defaut depuis tech-stack (variable mentale BASE_BRANCH)
2. Executer checkout BASE_BRANCH → pull → checkout -b nouvelle-branche
3. Interdiction explicite de hardcoder main ou develop

## Fichiers modifies

- `skills/pipe-code/SKILL.md` — remplacement de l'etape 1 par des instructions prescriptives avec commandes git exactes

## Points de review

- Verifier que la reference "deja lu a l'etape 0" est coherente (l'etape 0 charge bien tech-stack)
- L'instruction "Annonce la branche creee" est conservee

## Tests

Pas de tests automatises — skill markdown. Verification manuelle de la coherence du flow etape 0 → etape 1.