### PR TITLE
[Feat] pipe-plan : multi-plateforme, JIRA, classification et concision

### DIFF
--- a/skills/pipe-plan/SKILL.md
+++ b/skills/pipe-plan/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pipe-plan
-description: Planifier l'implementation d'une issue GitHub. Analyse le code, produit un plan technique detaille avec etapes, fichiers et approche. Utiliser avant /pipe-code.
+description: Planifier l'implementation d'une issue ou d'un ticket. Detecte la plateforme git (GitHub, GitLab, Gitea) et supporte les trackers externes (JIRA, Linear). Analyse le code, classifie le ticket (technique/metier/mixte), decompose si necessaire, et produit un plan technique detaille. Utiliser avant /pipe-code.
 model: opus
-argument-hint: [numero issue, URL ou texte]
+argument-hint: [numero issue, URL, cle JIRA ou texte]
 ---
 
 ## Contexte
@@ -11,67 +11,129 @@ Utilise Read pour charger `${CLAUDE_SKILL_DIR}/../_workflow-persona/SKILL.md` av
 
 ---
 
-## Etape 0 — Verifications
+## Etape 0 — Detecter l'environnement
 
-Avant de commencer, verifie :
+### Plateforme git
 
-- [ ] Le repo a un remote `origin` configure (necessaire pour recuperer l'issue)
-- [ ] L'argument fourni permet d'identifier une issue (numero, URL ou texte)
+Recupere l'URL du remote origin (`git remote get-url origin`) et deduis la plateforme :
+
+| Domaine | Plateforme | MCP |
+|---------|-----------|-----|
+| `github.com` | GitHub | `mcp__github__` |
+| `gitlab.com` ou `gitlab.*` | GitLab | `mcp__gitlab__` |
+| Autre | Gitea | `mcp__gitea__` |
+
+Si `.claude/skills/workflow-config/SKILL.md` existe, sa configuration a priorite sur la detection automatique.
+
+### Tracker externe (optionnel)
+
+Si l'argument ressemble a une cle de projet externe ou si le workflow-config mentionne un tracker, utilise le MCP correspondant :
+
+| Pattern | Tracker | MCP |
+|---------|---------|-----|
+| `ABC-123` (lettres majuscules-chiffres) | JIRA | `mcp__atlassian__` |
+| URL `*.atlassian.net/*` | JIRA | `mcp__atlassian__` |
+| URL `linear.app/*` | Linear | MCP Linear si disponible |
+
+Si aucun tracker externe n'est detecte, le ticket vient de la plateforme git.
+
+### Verifications
+
+Avant de continuer, verifie :
+
+- [ ] Le repo a un remote `origin` configure
+- [ ] L'argument permet d'identifier un ticket (numero, URL, cle ou texte)
+- [ ] Le MCP necessaire est disponible (sinon, signale-le et propose des alternatives)
 
 Si une verification echoue, signale-le clairement et arrete-toi.
 
-## Etape 1 — Identifier et recuperer l'issue
+## Etape 1 — Recuperer le ticket
 
-L'argument peut prendre plusieurs formes. Adapte-toi :
+L'argument peut prendre plusieurs formes :
 
-- `42` → numero d'issue, utilise le repo detecte via `git remote origin`
-- `https://github.com/org/repo/issues/42` → extrais org, repo, numero
-- `titre partiel` ou texte libre → recherche dans les issues ouvertes du repo courant, prends la correspondance la plus proche, confirme avec l'utilisateur si ambigu
+- `42` ou `#42` → issue sur la plateforme git detectee, via le MCP correspondant
+- `https://github.com/org/repo/issues/42` → extrais plateforme, org, repo, numero depuis l'URL
+- `https://gitlab.com/org/repo/-/issues/42` → idem pour GitLab
+- `https://org.atlassian.net/browse/PROJ-42` → ticket JIRA via MCP Atlassian
+- `PROJ-42` → cle JIRA, utilise le MCP Atlassian
+- Texte libre → recherche dans les issues ouvertes du repo, confirme avec l'utilisateur si ambigu
 
-Recupere l'issue complete via le MCP GitHub (titre, body, labels, commentaires si presents).
+Recupere le ticket complet (titre, body, labels/tags, commentaires pertinents).
 
-## Etape 2 — Explorer le codebase
+## Etape 2 — Classifier le ticket
 
-Avant de planifier, explore la structure du projet pour ancrer le plan dans la realite du code existant. Utilise les outils de lecture (Read, Glob, Grep) pour :
+Utilise Read pour charger `reference.md` — il contient les criteres de classification et le template de plan.
 
-- Identifier les fichiers et modules concernes par l'issue
-- Comprendre les patterns deja en place (conventions, architecture, abstractions existantes)
+Determine la nature du ticket selon les criteres de `reference.md` :
+
+- **Technique** : dette, refactoring, perf, infra, CI/CD, migration, tooling
+- **Metier** : fonctionnalite utilisateur, user story, besoin business, UX/UI
+- **Mixte** : besoin metier qui implique des changements techniques significatifs
+
+Annonce la classification a l'utilisateur — elle oriente le plan.
+
+## Etape 3 — Evaluer la taille et decomposer si necessaire
+
+Evalue si le ticket est implementable en une seule session `/pipe-code`. Consulte les criteres de decomposition dans `reference.md`.
+
+**Si le ticket est trop large :**
+
+1. Propose un decoupage en sous-tickets (voir guide dans `reference.md`)
+2. Demande confirmation a l'utilisateur
+3. Cree les sous-tickets sur la plateforme detectee via le MCP correspondant
+4. Continue en planifiant le premier sous-ticket
+
+**Si le ticket est de taille raisonnable**, passe directement a la suite.
+
+## Etape 4 — Explorer le codebase
+
+Explore la structure du projet avec Read, Glob, Grep pour :
+
+- Identifier les fichiers et modules concernes
+- Comprendre les patterns en place (conventions, architecture, abstractions)
 - Reperer les dependances et les zones impactees
 
-## Etape 3 — Analyser l'issue
+## Etape 5 — Produire le plan technique
 
-A partir de l'issue et de l'exploration du code, comprends precisement :
+Structure le plan selon le template dans `reference.md`. Le plan doit etre **actionnable par `/pipe-code`** : chemins reels, signatures concretes, logique explicite.
 
-- **Nature** : bug, feature, refactor, chore ?
-- **Perimetre** : quelles couches sont impactees ? (domaine, infra, API, UI, config...)
-- **Dependances** : est-ce que ca necessite qu'une autre issue soit faite avant ?
-- **Risques** : y a-t-il des effets de bord potentiels ? Des zones sensibles a ne pas toucher ?
-- **Criteres d'acceptance** : qu'est-ce qui definit "c'est termine" ?
+### Concision
 
-## Etape 4 — Produire le plan technique
+Un plan est une **feuille de route**, pas du code. `/pipe-code` ecrira le code — le plan lui dit quoi faire et pourquoi.
 
-Utilise Read pour charger `reference.md` — il contient le template de plan et les regles de precision.
+- **Budget : 80-120 lignes** pour un ticket simple, jusqu'a 150 pour un ticket decompose
+- **Pas de blocs de code** dans le plan. Les signatures de fonctions, noms de types et descriptions textuelles suffisent. Exemple : "Creer `DaylogAnalyticsService` avec methodes `getMonthTotals(month: string)`, `listByPeriod(period, month)`, `getTodayLog()`" — pas besoin d'ecrire la classe
+- **Terminer par un tableau recapitulatif** des fichiers (chemin | action | description courte) — scannable en 5 secondes
 
-Structure le plan selon le template : vue d'ensemble, approche technique, etapes d'implementation (avec fichiers reels), tests, points d'attention.
+### Decomposition
 
-## Etape 5 — Persister le plan dans un fichier
+Quand le ticket est decompose en sous-tickets (etape 3) :
+- **Plan detaille uniquement pour le 1er sous-ticket** (celui qu'on implemente next)
+- **Resume en 2-3 lignes pour chaque sous-ticket suivant** : description + fichiers principaux + classification
+- Les sous-tickets suivants seront planifies a leur tour via `/pipe-plan`
 
-Ecris le plan dans `.claude/plans/plan-<numero-issue>.md` (ou `plan-<slug>.md` si pas de numero d'issue).
+### Niveau de detail selon la classification
 
-Cree le repertoire `.claude/plans/` s'il n'existe pas.
+- **Metier** → insiste sur le comportement attendu cote utilisateur
+- **Technique** → insiste sur les contraintes d'implementation et risques de regression
+- **Mixte** → couvre les deux aspects
 
-Le fichier de plan permet de :
-- Reprendre le travail dans une session fraiche sans perdre le contexte
-- Lancer `/pipe-code` depuis un terminal different avec un contexte propre
+## Etape 6 — Persister le plan
 
-## Etape 6 — Confirmer et proposer /code
+Ecris le plan dans `.claude/plans/plan-<identifiant>.md` :
+- Issue git : `plan-42.md`
+- Ticket JIRA : `plan-PROJ-42.md`
+- Texte libre : `plan-<slug>.md`
 
-Demande a l'utilisateur de valider le plan. Une fois confirme, propose de lancer `/pipe-code` pour implementer.
+Cree le repertoire `.claude/plans/` si necessaire.
+
+## Etape 7 — Confirmer et proposer la suite
 
 ```
 ---
+Classification : [technique | metier | mixte]
 Plan ecrit dans `.claude/plans/plan-XX.md`.
-Ce plan te convient ? Tu veux que je lance `/pipe-code` pour implementer ca ?
+Ce plan te convient ? Tu veux que je lance `/pipe-code` pour implementer ?
 ```
 
 ---

--- a/skills/pipe-plan/reference.md
+++ b/skills/pipe-plan/reference.md
@@ -1,42 +1,97 @@
-# Prepare Plan — Template de plan technique
+# Pipe Plan — References
 
-## Structure du plan
+## Template de plan technique
 
 ```markdown
-## Plan — [Titre de l'issue] (#XX)
+## Plan — [Titre du ticket] (#XX / PROJ-XX)
 
 ### Vue d'ensemble
 Resume en 2-3 phrases de ce qu'on va faire et pourquoi.
 
+**Classification :** technique | metier | mixte
+**Source :** GitHub #42 | GitLab #42 | JIRA PROJ-42
+
 ### Approche technique
-Explique le raisonnement : quel pattern, quelle architecture, pourquoi ce choix.
-Signale les alternatives ecartees si c'est pertinent.
+Raisonnement : quel pattern, quelle architecture, pourquoi ce choix.
+Alternatives ecartees si pertinent (1-2 lignes chacune, pas de dissertation).
 
 ### Etapes d'implementation
 
 #### 1. [Nom de l'etape]
-**Fichiers concernes :**
-- `chemin/vers/fichier.ts` — ce qu'on y fait precisement (creer / modifier / supprimer)
-- `chemin/vers/autre.ts` — idem
-
-**Ce qu'on implemente :**
-Description precise des changements : signature des fonctions, structure des classes, logique metier, etc. Pas de pseudo-code vague — si c'est utile, donne un exemple concret.
+- `chemin/vers/fichier.ts` — creer | modifier | supprimer
+- Description textuelle des changements : noms de fonctions, signatures, logique
+- Pas de bloc de code — decrire en langage naturel ce que /pipe-code devra ecrire
 
 #### 2. [Nom de l'etape]
 ...
 
 ### Tests
-Quoi tester, ou, et comment. Unitaires / integration / e2e selon ce qui est pertinent.
+Quoi tester, ou, comment. 2-5 bullet points max.
 
 ### Points d'attention
 - Effets de bord potentiels
-- Ce qu'il ne faut surtout pas casser
-- Contraintes techniques connues
+- Zones sensibles
+- Contraintes techniques
+
+### Recapitulatif des fichiers
+
+| Fichier | Action | Description |
+|---------|--------|-------------|
+| `chemin/fichier.ts` | creer | Breve description |
+| `chemin/autre.ts` | modifier | Ce qui change |
 ```
 
-## Regles de precision
+## Regles
 
 - Les chemins de fichiers doivent correspondre a la structure reelle du projet (verifies lors de l'exploration)
-- Si un fichier n'existe pas encore, indique-le clairement : `(a creer)`
-- Pas d'etape floue. Si tu ne sais pas comment implementer quelque chose, dis-le explicitement plutot que de rester vague
-- Ordre des etapes = ordre logique d'implementation (les dependances d'abord)
+- Si un fichier n'existe pas encore, indique-le : `(a creer)`
+- Pas d'etape floue — si tu ne sais pas comment implementer quelque chose, dis-le explicitement
+- Ordre des etapes = ordre logique d'implementation (dependances d'abord)
+- **Pas de blocs de code** dans le plan. Decrire les changements en langage naturel avec les noms de fonctions, types et signatures. Le code sera ecrit par `/pipe-code`
+- **Budget : 80-120 lignes** pour un ticket simple, 150 max pour un ticket decompose. Si le plan depasse, c'est probablement qu'il contient du code ou des details d'implementation qui appartiennent a `/pipe-code`
+
+## Criteres de classification
+
+| Type | Signaux | Exemples |
+|------|---------|----------|
+| **Technique** | refactor, migration, perf, CI, lint, deps, infra, dette, tooling | "Migrer de Express a Fastify", "Ajouter le linting" |
+| **Metier** | utilisateur, fonctionnalite, UX, dashboard, ecran, bouton, workflow, export | "Ajouter un graphique de suivi", "Export CSV" |
+| **Mixte** | Besoin metier + changement architectural significatif | "Ajouter l'authentification OAuth" (login user + couche auth) |
+
+Le type **mixte** est le plus frequent en pratique : la plupart des features metier impliquent du travail technique. Reserve **technique pur** aux tickets sans impact utilisateur visible, et **metier pur** aux tickets qui n'ajoutent pas de nouvelle couche technique.
+
+## Guide de decomposition
+
+### Quand decomposer
+
+Un ticket merite d'etre decompose quand :
+- Il touche **>3 modules** distincts
+- Il impacte **>2 couches** d'architecture (data, domaine, API, UI)
+- Il contient **plusieurs features independantes** emballees ensemble
+- Son implementation depasse ce qu'une seule session `/pipe-code` peut couvrir
+
+### Principes de decoupage
+
+- Chaque sous-ticket est **implementable independamment** et apporte de la valeur
+- L'ordre respecte les **dependances** (schema DB avant API, API avant UI)
+- Les sous-tickets techniques precedent les sous-tickets metier quand ils sont pre-requis
+- Chaque sous-ticket a un **critere d'acceptance clair**
+- Classifier chaque sous-ticket independamment (technique, metier ou mixte)
+
+### Format de sortie pour un ticket decompose
+
+1. **Liste des sous-tickets** avec pour chacun : classification, titre, 1-2 lignes de description, dependances
+2. **Plan detaille uniquement pour le sous-ticket 1** (le template complet ci-dessus)
+3. Les sous-tickets suivants seront planifies via `/pipe-plan` au moment de les implementer
+
+### Exemple
+
+Ticket : "Ajouter un systeme de notifications temps reel"
+
+1. **[Technique]** Mettre en place le serveur WebSocket — infra de base, depend de rien
+2. **[Technique]** Creer le modele Notification en base — schema + migration, depend de rien
+3. **[Mixte]** Implementer l'API de notifications — CRUD + logique metier, depend de 1 et 2
+4. **[Metier]** Ajouter le composant notifications dans l'UI — bell + dropdown, depend de 3
+5. **[Metier]** Ajouter les preferences de notification utilisateur — settings, depend de 3
+
+→ Plan detaille pour le sous-ticket 1 uniquement. Les autres seront planifies ensuite.


### PR DESCRIPTION
## Contexte

Le skill `pipe-plan` ne supportait que GitHub et ne connaissait pas les trackers externes comme JIRA. Les plans générés étaient trop verbeux (~256 lignes en moyenne) pour être réellement utiles comme input pour `/pipe-code`.

## Ce qui a été fait

**Détection de plateforme** : le skill détecte automatiquement la plateforme git (GitHub, GitLab, Gitea) depuis l'URL du remote `origin` et utilise le MCP correspondant.

**Support des trackers externes** : détection du pattern JIRA (`ABC-123`) dans le prompt, tentative via `mcp__atlassian__`, fallback gracieux sur la description fournie si MCP indisponible.

**Classification** : chaque ticket est classifié `technique` / `métier` / `mixte` avec des critères explicites dans le reference.md.

**Décomposition intelligente** : si le ticket dépasse 3 modules ou 2 couches d'architecture, le skill propose un découpage en sous-tickets classifiés avec dépendances. Le plan détaillé ne couvre que le premier sous-ticket.

**Concision** : budget de 80-120 lignes (vs ~256 avant). Template mis à jour : bullets à la place de blocs de code, tableau récapitulatif des fichiers.

## Fichiers modifiés

- `skills/pipe-plan/SKILL.md` — réécriture des 7 étapes : détection plateforme/tracker, classification, décomposition, règles de concision
- `skills/pipe-plan/reference.md` — template mis à jour, règles de concision, guide de classification et décomposition

## Points de review

- La détection de plateforme repose sur le parsing de `git remote get-url origin` — les formats edge-case (SSH custom, Gitea self-hosted) sont couverts dans le tableau de référence
- Le budget 80-120 lignes est une instruction au LLM, pas un hard limit technique — les evals confirment que ça tient en pratique
- Le guide de décomposition est intentionnellement conservateur pour ne pas sur-découper des tickets de taille moyenne

## Tests

Validé par eval loop (2 itérations sur le repo tracker — NestJS + Nuxt 3) :
- Pass rate `with_skill` : **100%** (15/15 assertions) vs **60%** sans (9/15)
- Réduction des lignes : **-73%** en moyenne (286 → 77 lignes)
- 3 cas testés : refactoring technique, feature large (décomposition), ticket JIRA métier