### PR TITLE
[Feat] Ameliorer pipe-review (prompt expert) et renforcer auto-close des issues dans pipe-pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support JIRA et multi-plateforme dans `/pipe-plan` avec classification des issues et génération de plans plus concis ([#28](https://github.com/ToolsForSaaS/claude-workflow/pull/28))
+
+### Changed
+
+- Refonte de `/pipe-review` avec prompt expert structuré en 5 catégories d'analyse (bugs, sécurité, performance, architecture, types) et 3 niveaux de sévérité ([#29](https://github.com/ToolsForSaaS/claude-workflow/pull/29))
+- `/pipe-pr` impose désormais `Closes #XX` dans chaque body de PR pour l'auto-close automatique des issues au merge ([#29](https://github.com/ToolsForSaaS/claude-workflow/pull/29))
+
 ## [1.4.0](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.0) - 2026-03-29
 
 ### Added

--- a/skills/git-conventions/SKILL.md
+++ b/skills/git-conventions/SKILL.md
@@ -77,6 +77,10 @@ Format : `[Type] Titre de l'issue (#numero)`
 
 Pour rediger le body ou un commentaire d'iteration, utilise Read pour charger `reference.md` et suivre les templates.
 
+### Auto-close des issues (obligatoire)
+
+Le body de chaque PR doit contenir `Closes #XX` pour chaque issue liee. Cela ferme automatiquement les issues au merge. Si plusieurs issues sont concernees : `Closes #12, Closes #15`. Ne jamais omettre cette ligne.
+
 ### Regles de formatage MCP GitHub
 
 Ne jamais utiliser `\n` litteraux dans le parametre `body` des appels MCP GitHub (`create_pull_request`, `update_pull_request`, `add_issue_comment`). Utiliser de vrais sauts de ligne dans le texte, sinon les `\n` s'affichent en dur dans le markdown.

--- a/skills/git-conventions/reference.md
+++ b/skills/git-conventions/reference.md
@@ -31,6 +31,8 @@
 
 ## Template PR — Body
 
+**Important** : `Closes #XX` est obligatoire, pas optionnel. Toujours present avec le bon numero d'issue. Si plusieurs issues sont liees : `Closes #12, Closes #15`.
+
 ```markdown
 ## Contexte
 
@@ -55,8 +57,6 @@ Ce sur quoi le reviewer doit porter son attention en priorite. Decisions techniq
 
 Ce qui a ete teste, comment. Si rien n'a ete teste, le dire explicitement avec la raison.
 ```
-
-**Important** : `Closes #XX` est obligatoire, pas optionnel. Toujours present avec le bon numero d'issue. Si plusieurs issues sont liees : `Closes #12, Closes #15`.
 
 ## Template PR — Commentaire d'iteration
 

--- a/skills/git-conventions/reference.md
+++ b/skills/git-conventions/reference.md
@@ -56,6 +56,8 @@ Ce sur quoi le reviewer doit porter son attention en priorite. Decisions techniq
 Ce qui a ete teste, comment. Si rien n'a ete teste, le dire explicitement avec la raison.
 ```
 
+**Important** : `Closes #XX` est obligatoire, pas optionnel. Toujours present avec le bon numero d'issue. Si plusieurs issues sont liees : `Closes #12, Closes #15`.
+
 ## Template PR — Commentaire d'iteration
 
 Utilise uniquement lors de la mise a jour d'une PR existante. Liste tous les commits depuis la derniere mise a jour.

--- a/skills/pipe-pr/SKILL.md
+++ b/skills/pipe-pr/SKILL.md
@@ -49,6 +49,15 @@ Utilise Read pour charger `${CLAUDE_SKILL_DIR}/../git-conventions/SKILL.md` (sec
 
 Que ce soit pour une nouvelle PR ou une mise a jour, la description suit le format defini dans git-conventions et doit toujours refleter l'etat actuel complet de la PR — jamais de mention "ajoute", "mis a jour" ou "nouveau". C'est le role du commentaire d'iteration (etape 4).
 
+### Auto-close des issues (obligatoire)
+
+Le body de la PR doit **toujours** contenir `Closes #XX` dans la section Contexte pour chaque issue liee. Cela ferme automatiquement les issues au merge.
+
+- Une issue : `Closes #42`
+- Plusieurs issues : `Closes #12, Closes #15`
+
+Si aucune issue n'est identifiable depuis le nom de branche, demande le numero a l'utilisateur avant de continuer — ne jamais omettre cette ligne.
+
 ## Etape 4 — Rediger le commentaire d'iteration (mise a jour uniquement)
 
 Cette etape ne s'applique que si une PR existe deja. Sinon, passe directement a l'etape 5.

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pipe-review
-description: Review automatique du code via sub-agent. Verifie patterns, complexite, edge cases et securite. Utiliser apres /pipe-code et avant /pipe-test.
+description: Review automatique du code via sub-agent. Analyse bugs, securite, performance, architecture et types avec rapport structure. Utiliser apres /pipe-code et avant /pipe-test.
 model: sonnet
 ---
 
@@ -12,73 +12,102 @@ Utilise Read pour charger `${CLAUDE_SKILL_DIR}/../_workflow-persona/SKILL.md` av
 
 ## Etape 0 — Verifications
 
-- [ ] Il y a des changements a reviewer (au moins un commit d'avance sur la branche par defaut)
 - [ ] La branche courante n'est pas la branche par defaut
+- [ ] Il y a au moins un commit d'avance sur la branche par defaut
 
 Si rien a reviewer, signale-le et arrete-toi.
 
-## Etape 1 — Collecter le contexte
+## Etape 1 — Charger le contexte projet
+
+- Utilise Read pour charger `CLAUDE.md` a la racine du repo (si absent, continue sans)
+- Utilise Read pour charger `.claude/_review-persona.md` (si present — personnalisation projet-specifique du style de review)
+
+## Etape 2 — Collecter le contexte
 
 Rassemble les informations necessaires :
 
 - **Diff complet** de la branche vs branche par defaut (`git diff <branche-defaut>...HEAD`)
 - **Liste des fichiers** modifies et crees
+- **Contenu integral** de chaque fichier modifie via Read (pas seulement le diff — le reviewer a besoin du contexte complet)
 - **Issue liee** (depuis le numero dans le nom de branche, ex: `feat/42-...` → issue #42)
 
-## Etape 2 — Lancer la review en sub-agent
+## Etape 3 — Lancer la review en sub-agent
 
-Utilise Read pour charger `${CLAUDE_SKILL_DIR}/../audit-naming/reference.md` (referentiel de conventions de nommage).
+Lance un **sub-agent** (Agent tool, type `general-purpose`, model `sonnet`) pour isoler la review du contexte principal. Passe-lui le diff, la liste des fichiers, le contenu de `CLAUDE.md` (si charge) et le contenu de `_review-persona.md` (si charge). Le sub-agent lit chaque fichier modifie en entier via Read.
 
-Lance un **sub-agent** (Agent tool, type `general-purpose`, model `sonnet`) pour isoler la review du contexte principal. Injecte le referentiel de nommage dans le prompt. Passe-lui ce prompt :
+Prompt du sub-agent :
 
 ```
-Tu es un reviewer de code senior. Review les changements sur la branche courante.
+Tu es un reviewer expert. Ton role est de detecter les vrais problemes et de les signaler directement, au bon endroit, de facon actionnable.
 
-Lis chaque fichier modifie ou cree et verifie :
+Lis chaque fichier modifie dans son integralite via Read, puis analyse les changements en profondeur.
 
-1. **Patterns du projet** — le code suit les conventions existantes, pas de nouvelle abstraction injustifiee
-2. **Complexite** — pas de fonction > 40 lignes, pas de nesting > 3 niveaux, logique lisible
-3. **Edge cases** — null, vide, erreurs, cas limites couverts
-4. **Securite** — pas d'injection, XSS, secrets en dur, donnees sensibles loguees
-5. **Code mort** — pas de code commente, imports inutilises, variables orphelines
-6. **Taille des fichiers** — aucun fichier > 300 lignes
-7. **Nommage** — coherent avec le reste du codebase, conforme au referentiel de conventions de nommage (voir section Referentiel ci-dessous)
-8. **Duplication** — pas de copier-coller d'un pattern qui existe deja
+Pour chaque fichier, cherche activement :
 
-Referentiel de conventions de nommage :
-[contenu de audit-naming/reference.md]
+**Bugs et correctness**
+- Logique incorrecte, cas limites non geres, conditions inversees
+- Race conditions, mutations inattendues, effets de bord
+- Promesses non awaited, erreurs silencieuses
+
+**Securite**
+- Injection (SQL, commande, XSS), donnees non validees cote serveur
+- Secrets exposes, permissions trop larges, IDOR
+
+**Performance**
+- N+1 queries, appels redondants en boucle
+- Chargements bloquants inutiles, fuites memoire
+
+**Architecture et maintenabilite**
+- Violation des conventions du projet (voir CLAUDE.md ci-dessous si fourni)
+- Couplage fort, responsabilites melangees
+- Duplication de logique metier critique
+
+**Types et contrats**
+- `any` injustifie, assertions forcees (`as`, `!`) sans garde
+- Props/parametres mal types, retours inconsistants
 
 Pour chaque probleme, donne :
 - Fichier et ligne
-- Categorie (pattern, complexite, edge-case, securite, code-mort, taille, nommage, duplication)
-- Severite (bloquant, avertissement, suggestion)
-- Description precise et correction proposee
+- Severite : BLOQUANT (bug, faille, regression) / AVERTISSEMENT (dette significative) / SUGGESTION (lisibilite, robustesse)
+- Description en 1-2 phrases centree sur l'impact
+- Correction proposee
 
-Produis un rapport structure avec un statut global : OK, AVERTISSEMENTS, ou BLOQUANT.
+**Ce que tu ne fais PAS :**
+- Pas de commentaire sur le style ou le formatting (c'est le role de Biome/ESLint)
+- Pas de reformulation de ce que fait le code
+- Pas de compliments generiques
+- Pas de rapport exhaustif de tous les changements
+
+**Style** : ecris comme si tu parlais a un developpeur competent. Une phrase pour le probleme, une pour la correction — pas plus. L'impact doit etre immediatement comprehensible (ex: "ca peut crasher si X est null" plutot que "violation du principe de null-safety").
+
+Produis un rapport structure avec statut global : OK, AVERTISSEMENTS, ou BLOQUANT.
 ```
 
-## Etape 3 — Afficher le rapport
+## Etape 4 — Afficher le rapport
 
 Affiche le rapport du sub-agent dans ce format :
 
 ```
 ## Review — [branche]
 
-### Statut : ✅ OK / ⚠️ Avertissements / ❌ Bloquant
+### Statut : OK / Avertissements / Bloquant
 
 ### Problemes bloquants (a corriger avant de continuer)
-- `fichier.ts:42` — [categorie] description du probleme
+- `fichier.ts:42` description du probleme
   → Correction proposee
 
 ### Avertissements
-- `fichier.ts:15` — [categorie] description
+- `fichier.ts:15` description
   → Suggestion
 
-### Points positifs
-- Ce qui est bien fait dans cette implementation
+### Suggestions
+- `fichier.ts:8` description
+  → Suggestion
 ```
 
-## Etape 4 — Corrections et suite
+Si aucun probleme dans une categorie, ne pas afficher la section (pas de liste vide).
+
+## Etape 5 — Corrections et suite
 
 Selon le statut :
 


### PR DESCRIPTION
## Contexte

Deux ameliorations au workflow PR : le skill `pipe-review` recoit un nouveau prompt de reviewer expert structure, et la regle `Closes #XX` devient obligatoire dans toutes les PRs creees par `pipe-pr`.

## Ce qui a ete fait

`pipe-review` est reecrit avec un prompt oriente impact : 5 categories d'analyse (bugs, securite, performance, architecture, types), 3 niveaux de severite (BLOQUANT/AVERTISSEMENT/SUGGESTION), chargement du contexte projet via `CLAUDE.md` et `_review-persona.md`, et lecture integrale des fichiers modifies. Le reviewer a des contraintes explicites sur ce qu'il ne fait pas (pas de style, pas de compliments generiques).

`pipe-pr` impose desormais `Closes #XX` dans chaque body de PR et demande le numero d'issue si non detectable depuis le nom de branche. La meme regle est ajoutee dans `git-conventions` comme convention de reference.

## Fichiers modifies

- `skills/pipe-review/SKILL.md` — reecriture complete du prompt reviewer expert
- `skills/pipe-pr/SKILL.md` — ajout regle auto-close obligatoire
- `skills/git-conventions/SKILL.md` — convention auto-close ajoutee
- `skills/git-conventions/reference.md` — note obligatoire deplacee avant le template
- `CHANGELOG.md` — entrees Unreleased ajoutees

## Points de review

Le prompt du sub-agent dans `pipe-review` liste des patterns JS/TS (race conditions, promesses) qui peuvent etre hors-sujet sur des projets non-JS — choix delibere de garder un prompt generaliste plutot que de le fragmenter par type de fichier.

## Tests

Pas de tests automatises sur ce repo. Verifie manuellement que les fichiers SKILL.md sont syntaxiquement corrects (frontmatter valide, `$ARGUMENTS` present sur les skills invocables).