### PR TITLE
[Feature] pipe-changelog : ajout de TECHNICAL_CHANGES.md en complement du CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "description": "Pipeline AI-Driven Development : setup, plan, code, review, test, PR",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": {
     "name": "ToolsForSaaS"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.5] - 2026-04-17
+
 ### Changed
 
-- `/pipe-changelog` genere et maintient desormais **deux fichiers** : `CHANGELOG.md` (orienté consommateur) et `TECHNICAL_CHANGES.md` (orienté contributeur, pour les changements techniques internes — refactors, docs internes, tests, CI, dependances, chore). Chaque commit est classe automatiquement dans un seul des deux fichiers selon son prefixe
+- `/pipe-changelog` genere et maintient desormais **deux fichiers** : `CHANGELOG.md` (orienté consommateur) et `TECHNICAL_CHANGES.md` (orienté contributeur, pour les changements techniques internes — refactors, docs internes, tests, CI, dependances, chore). Chaque commit est classe automatiquement dans un seul des deux fichiers selon son prefixe ([`c524b13`](https://github.com/ToolsForSaaS/claude-workflow/commit/c524b13))
 
 ## [1.4.4] - 2026-04-17
 
@@ -148,7 +150,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...HEAD
+[1.4.5]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.4...v1.4.5
+[1.4.4]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.0...v1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `/pipe-changelog` genere et maintient desormais **deux fichiers** : `CHANGELOG.md` (orienté consommateur) et `TECHNICAL_CHANGES.md` (orienté contributeur, pour les changements techniques internes — refactors, docs internes, tests, CI, dependances, chore). Chaque commit est classe automatiquement dans un seul des deux fichiers selon son prefixe
+
 ## [1.4.4] - 2026-04-17
 
 ### Added

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -93,7 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renommer le plugin et ajouter `.gitignore` ([`3f0423a`](https://github.com/ToolsForSaaS/claude-workflow/commit/3f0423a))
 - Supprimer le tableau de routage des skills et le template d'index devenus obsoletes ([`88ef12c`](https://github.com/ToolsForSaaS/claude-workflow/commit/88ef12c))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...HEAD
 [1.4.2]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.3.3...v1.4.0

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -1,0 +1,105 @@
+# Technical Changes
+
+All notable technical changes targeted at contributors will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.4.2](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.2) - 2026-04-14
+
+### Docs
+
+- Retirer toutes les references a `pipe-notifier` dans les skills et dans `CLAUDE.md` apres sa suppression ([`12cd229`](https://github.com/ToolsForSaaS/claude-workflow/commit/12cd229), [`51a1a08`](https://github.com/ToolsForSaaS/claude-workflow/commit/51a1a08))
+
+## [1.4.1](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.1) - 2026-04-11
+
+### Docs
+
+- Reecrire le README avec guide d'utilisation et catalogue complet des 21 skills, ajouter la compatibilite Jira ([`696dc0c`](https://github.com/ToolsForSaaS/claude-workflow/commit/696dc0c), [`25e5ddc`](https://github.com/ToolsForSaaS/claude-workflow/commit/25e5ddc))
+- Ajouter la regle `Closes #XX` obligatoire dans le skill `git-conventions` et corriger la position de la note dans le template PR body ([`1276f89`](https://github.com/ToolsForSaaS/claude-workflow/commit/1276f89), [`3515326`](https://github.com/ToolsForSaaS/claude-workflow/commit/3515326))
+
+## [1.4.0](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.0) - 2026-03-29
+
+### Docs
+
+- Mentionner la convention `model` dans `CLAUDE.md` ([`1baed93`](https://github.com/ToolsForSaaS/claude-workflow/commit/1baed93))
+
+### Chore
+
+- Corriger les problemes de review remontes sur le skill `create-skill` apres l'integration du champ `model` ([`b2d8016`](https://github.com/ToolsForSaaS/claude-workflow/commit/b2d8016))
+
+## [1.3.3](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.3.3) - 2026-03-29
+
+### Docs
+
+- Corriger l'exemple de structure globale et preciser le format de `tagRef` dans le referentiel de `pipe-changelog` ([`6037eb4`](https://github.com/ToolsForSaaS/claude-workflow/commit/6037eb4))
+- Documenter le format des en-tetes de version avec lien conditionnel vers le tag dans le skill `pipe-changelog` ([`614501b`](https://github.com/ToolsForSaaS/claude-workflow/commit/614501b))
+
+## [1.3.2](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.3.2) - 2026-03-29
+
+### Chore
+
+- Corriger les violations de conventions du skill `pipe-tag` et l'integrer dans le pipeline ([`2523d5c`](https://github.com/ToolsForSaaS/claude-workflow/commit/2523d5c), [`1efd3e2`](https://github.com/ToolsForSaaS/claude-workflow/commit/1efd3e2))
+
+## [1.3.1] - 2026-03-29
+
+### Refactor
+
+- Simplifier les references dans `pipe-changelog` (PR uniquement avec SHA en fallback) et elargir les mots-cles de detection ([`c0df419`](https://github.com/ToolsForSaaS/claude-workflow/commit/c0df419), [`3d2c7ef`](https://github.com/ToolsForSaaS/claude-workflow/commit/3d2c7ef))
+
+### Docs
+
+- Creer le fichier `CHANGELOG.md` initial du projet ([`f7d8583`](https://github.com/ToolsForSaaS/claude-workflow/commit/f7d8583))
+- Ajouter la regle des liens Markdown explicites pour les references dans le skill `pipe-changelog` ([`be2f284`](https://github.com/ToolsForSaaS/claude-workflow/commit/be2f284))
+
+## [1.3.0] - 2026-03-29
+
+### Refactor
+
+- Deplacer le referentiel de nommage apres la liste numerotee dans le skill `pipe-review` ([`f5488dd`](https://github.com/ToolsForSaaS/claude-workflow/commit/f5488dd))
+
+## [1.1.0] - 2026-03-27
+
+### Refactor
+
+- Mettre le skill `create-skill` en conformite avec les bonnes pratiques du template canonique ([`c40b389`](https://github.com/ToolsForSaaS/claude-workflow/commit/c40b389))
+
+### Docs
+
+- Ajouter les instructions d'installation via la marketplace dans le README ([`4e491e6`](https://github.com/ToolsForSaaS/claude-workflow/commit/4e491e6))
+- Supprimer la section de migration `sync.sh` devenue obsolete ([`7618421`](https://github.com/ToolsForSaaS/claude-workflow/commit/7618421))
+
+## [1.0.0] - 2026-03-27
+
+### Refactor
+
+- Migrer tous les skills au format `directory/SKILL.md` et au chargement progressif via le pattern "utilise Read pour charger" ([`efa6e0e`](https://github.com/ToolsForSaaS/claude-workflow/commit/efa6e0e), [`fc2f3a7`](https://github.com/ToolsForSaaS/claude-workflow/commit/fc2f3a7), [`10ea164`](https://github.com/ToolsForSaaS/claude-workflow/commit/10ea164), [`40121fb`](https://github.com/ToolsForSaaS/claude-workflow/commit/40121fb))
+- Remplacer le systeme de commandes classiques par des skills unifies ([`ff02fe7`](https://github.com/ToolsForSaaS/claude-workflow/commit/ff02fe7))
+- Reorganiser l'arborescence : `commands/` et `skills/` dans `.claude/`, puis remontee a la racine du plugin avec references inter-skills adaptees ([`289f6d7`](https://github.com/ToolsForSaaS/claude-workflow/commit/289f6d7), [`9785305`](https://github.com/ToolsForSaaS/claude-workflow/commit/9785305), [`e1df8a4`](https://github.com/ToolsForSaaS/claude-workflow/commit/e1df8a4))
+- Renommer les skills selon la convention de nommage unifiee ([`8eaf6b4`](https://github.com/ToolsForSaaS/claude-workflow/commit/8eaf6b4))
+- Extraire le mode audit de `create-skill` dans le skill dedie `audit-skills` ([`20088cc`](https://github.com/ToolsForSaaS/claude-workflow/commit/20088cc))
+
+### Docs
+
+- Initialiser `CLAUDE.md` et le README du projet, puis les reecrire pour le contexte plugin ([`db2b40b`](https://github.com/ToolsForSaaS/claude-workflow/commit/db2b40b), [`7fafe62`](https://github.com/ToolsForSaaS/claude-workflow/commit/7fafe62), [`f7abc89`](https://github.com/ToolsForSaaS/claude-workflow/commit/f7abc89))
+- Ajouter la regle "utilise Read pour charger" dans la documentation de `create-skill` ([`93d1598`](https://github.com/ToolsForSaaS/claude-workflow/commit/93d1598))
+- Mettre a jour `CLAUDE.md` et le referentiel d'audit-grille pour refleter la structure plugin ([`571a9cc`](https://github.com/ToolsForSaaS/claude-workflow/commit/571a9cc), [`66cf839`](https://github.com/ToolsForSaaS/claude-workflow/commit/66cf839))
+
+### Chore
+
+- Initialiser le depot `claude-workflow` avec commandes, skills et scripts de sync ([`498f88a`](https://github.com/ToolsForSaaS/claude-workflow/commit/498f88a))
+- Renommer le plugin et ajouter `.gitignore` ([`3f0423a`](https://github.com/ToolsForSaaS/claude-workflow/commit/3f0423a))
+- Supprimer le tableau de routage des skills et le template d'index devenus obsoletes ([`88ef12c`](https://github.com/ToolsForSaaS/claude-workflow/commit/88ef12c))
+
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.3...HEAD
+[1.4.2]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.1...v1.4.2
+[1.4.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.3.3...v1.4.0
+[1.3.3]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.3.2...v1.3.3
+[1.3.2]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.2.4...v1.3.0
+[1.1.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.0.0

--- a/skills/pipe-changelog/SKILL.md
+++ b/skills/pipe-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pipe-changelog
-description: Generer ou mettre a jour le CHANGELOG.md depuis les commits/tags. Analyse les changements depuis la derniere version et respecte Keep a Changelog + SemVer. Utiliser apres /pipe-test et avant /pipe-pr.
+description: Generer ou mettre a jour CHANGELOG.md (consommateur) et TECHNICAL_CHANGES.md (contributeur) depuis les commits/tags. Analyse les changements depuis la derniere version et respecte Keep a Changelog + SemVer. Utiliser apres /pipe-test et avant /pipe-pr.
 model: sonnet
 argument-hint: [version a tagger ou rien pour Unreleased]
 ---
@@ -27,7 +27,7 @@ Recupere les informations necessaires :
 2. **URL du remote** — via `git remote get-url origin`, transforme en URL HTTPS pour les liens de comparaison (ex: `git@github.com:org/repo.git` → `https://github.com/org/repo`).
 3. **Phase de versioning** — si le dernier tag est `0.x.y`, on est en pre-v1.0.0. Sinon, post-v1.0.0.
 4. **Version cible** — si un argument est fourni (ex: `1.3.0`), c'est la version a publier. Sinon, on met a jour la section `[Unreleased]`.
-5. **Tags existants** — pour chaque version presente dans CHANGELOG.md (hors `[Unreleased]`) et pour la version cible, verifier si le tag existe :
+5. **Tags existants** — pour chaque version presente dans CHANGELOG.md ou TECHNICAL_CHANGES.md (hors `[Unreleased]`) et pour la version cible, verifier si le tag existe :
    - `git tag --list "v${version}"` → si resultat non vide, le tag `v${version}` existe
    - `git tag --list "${version}"` → fallback sans prefixe `v`
    - Construire un map `{ version → nom du tag tel que matche (ex: "v1.3.2") | null }` utilise a l'etape 3 pour generer les en-tetes de version
@@ -47,106 +47,127 @@ Contexte de versioning :
 Utilise Read pour charger `reference.md` (referentiel de conventions et mapping des types).
 
 1. **Lister les commits** — `git log <dernier-tag>..HEAD --format="%h %s"` (ou `git log --format="%h %s"` si aucun tag). Le `%h` donne le SHA court de chaque commit.
-2. **Filtrer les exclusions** — supprimer selon les regles du referentiel :
-   - Merges (`Merge branch...`, `Merge pull request...`)
-   - Fixups/squashs (`fixup!`, `squash!`)
-   - Commits CI/CD internes
-   - Mises a jour de dependances mineures (sauf impact API publique)
-   - Typos de commentaires ou docs internes
-3. **Detecter les changesets** — si `.changeset/` existe et contient des fichiers `.md`, les utiliser comme source primaire au lieu des commits
-4. **Classer par type** — utiliser le mapping prefixe → type CHANGELOG du referentiel
+2. **Filtrer les exclusions** — supprimer les commits exclus des deux fichiers selon la section "Exclusions" du referentiel (merges, fixups, typos purs, reverts annules). CI/CD, bumps de deps et docs internes ne sont pas exclus — ils vont dans TECHNICAL.
+3. **Detecter les changesets** — si `.changeset/` existe et contient des fichiers `.md`, les utiliser comme source primaire au lieu des commits (uniquement pour CHANGELOG.md — les changesets ne couvrent pas le contenu technique).
+4. **Classer dans le bon fichier** — pour chaque commit retenu, utiliser le mapping "prefixe → fichier + type" du referentiel :
+   - `feat`, `fix`, `perf` → CHANGELOG
+   - `refactor`, `docs`, `chore`, `test` → TECHNICAL par defaut ; CHANGELOG si impact consommateur avere (API publique modifiee, doc user-facing, config publique)
+   - En cas de doute entre les deux fichiers, privilegier TECHNICAL et demander confirmation
 5. **Enrichir avec les references** — pour chaque commit retenu, trouver la PR associee :
    - Utiliser `gh pr list --state merged --search "SHA" --json number --jq '.[0].number'` pour trouver la PR qui a merge ce commit.
    - Si une PR est trouvee, c'est la reference de l'entree. Si pas de PR (commit direct), utiliser le SHA court en fallback.
    - Si `gh` echoue ou est indisponible, utiliser le SHA seul — ne pas bloquer la generation.
-6. **Reformuler** — chaque entree est redigee pour le consommateur selon les principes de la section "Rediger pour le consommateur" de `reference.md` : exposer l'effet observable, expliciter les valeurs concretes, fusionner les entrees liees qui decrivent un meme changement, indiquer l'impact client. Chaque entree tient sur **une seule ligne** — pas de retour a la ligne manuel dans la phrase. Terminer chaque entree par la reference entre parentheses avec un lien Markdown explicite selon le format defini dans `reference.md` (section "References dans les entrees"). L'URL de base du remote est detectee a l'etape 1.
+6. **Reformuler** —
+   - Pour CHANGELOG : appliquer les principes de la section "Rediger pour le consommateur" de `reference.md` (effet observable, valeurs concretes, fusion des entrees liees, impact client).
+   - Pour TECHNICAL : entree concise orientee contributeur (ce qui a change dans le repo), meme regle d'une seule ligne et meme reference tracable.
+   - Chaque entree tient sur **une seule ligne** et se termine par la reference entre parentheses avec un lien Markdown explicite (voir section "References dans les entrees" de `reference.md`). L'URL de base du remote est detectee a l'etape 1.
 
-Affiche les entrees classees avant de continuer :
+Affiche les entrees classees avant de continuer, en deux blocs distincts :
 
 ```
 Changements detectes :
 
+=== CHANGELOG.md (consommateur) ===
+
 ### Added
 - [entree reformulee] ([#15](url/pull/15))
-
-### Changed
-- [entree reformulee] ([#8](url/pull/8))
 
 ### Fixed
 - [entree reformulee] ([`9a8b7c6`](url/commit/9a8b7c6))
 
-[N] commits exclus (merges, fixups, CI...)
+=== TECHNICAL_CHANGES.md (contributeur) ===
+
+### Refactor
+- [entree technique] ([#12](url/pull/12))
+
+### Dependencies
+- [entree technique] ([`a1b2c3d`](url/commit/a1b2c3d))
+
+[N] commits exclus (merges, fixups, typos...)
 ```
 
 Demande confirmation si le classement semble correct avant de continuer.
 
 ## Etape 2.5 — Auditer la coherence historique
 
-Avant de toucher aux entrees, verifier que le CHANGELOG existant ne contient pas d'entrees mal placees : une PR mergee apres la date d'un tag ne peut pas figurer sous la section de ce tag.
+Avant de toucher aux entrees, verifier que **CHANGELOG.md et TECHNICAL_CHANGES.md** ne contiennent pas d'entrees mal placees : une PR mergee apres la date d'un tag ne peut pas figurer sous la section de ce tag.
 
-Procedure (voir `reference.md` section "Coherence versions/dates") :
+Procedure (voir `reference.md` section "Coherence versions/dates") a appliquer **sur chacun des deux fichiers** :
 
-1. Pour chaque section versionnee `[X.Y.Z] - YYYY-MM-DD` du CHANGELOG, recuperer la date du tag correspondant via `git log -1 --format=%aI v<X.Y.Z>` (fallback sans prefixe `v`).
+1. Pour chaque section versionnee `[X.Y.Z] - YYYY-MM-DD` du fichier, recuperer la date du tag correspondant via `git log -1 --format=%aI v<X.Y.Z>` (fallback sans prefixe `v`). Si le tag n'existe pas, passer la section — pas d'audit possible.
 2. Pour chaque entree sous cette section, extraire la reference (PR ou SHA) et recuperer sa date :
    - PR : `gh pr view <N> --json mergedAt --jq .mergedAt`
    - SHA : `git log -1 --format=%aI <sha>`
-3. Si la date de la reference est **posterieure** a la date du tag, l'entree doit etre deplacee vers `[Unreleased]`.
+3. Si la date de la reference est **posterieure** a la date du tag, l'entree doit etre deplacee vers le `[Unreleased]` du **meme fichier**.
 
-Si des entrees mal placees sont detectees, les lister clairement :
+Si des entrees mal placees sont detectees, les lister clairement en indiquant le fichier :
 
 ```
 Entrees mal placees (a deplacer vers [Unreleased]) :
+
+CHANGELOG.md :
 - Section [0.1.0] (tag du YYYY-MM-DD) :
   - PR #N (mergee le YYYY-MM-DD) : "texte de l'entree"
-  - ...
+
+TECHNICAL_CHANGES.md :
+- (aucune)
 ```
 
-Demander confirmation avant de reorganiser. Cette etape est rapide si le CHANGELOG est sain (aucune entree mal placee detectee) — la mentionner brievement et passer a l'etape suivante.
+Demander confirmation avant de reorganiser. Cette etape est rapide si les deux fichiers sont sains — la mentionner brievement et passer a l'etape suivante.
 
-## Etape 3 — Generer / mettre a jour le CHANGELOG
+## Etape 3 — Generer / mettre a jour les deux fichiers
 
-### Cas 1 : CHANGELOG.md n'existe pas
+Traiter **CHANGELOG.md** et **TECHNICAL_CHANGES.md** en appliquant la meme logique a chacun, avec son propre bucket d'entrees issu de l'etape 2.
+
+### Cas 1 : le fichier n'existe pas
 
 Creer le fichier complet avec :
-- Le header standard (voir referentiel, section "Structure globale")
+- Le header standard correspondant (voir referentiel : "Structure globale du CHANGELOG" pour `CHANGELOG.md`, "TECHNICAL_CHANGES.md — journal technique" pour `TECHNICAL_CHANGES.md`)
 - La section appropriee (`[Unreleased]` ou `[X.Y.Z] - YYYY-MM-DD`)
 - Les liens de comparaison en bas
 
-### Cas 2 : CHANGELOG.md existe
+Si aucune entree technique n'est detectee, `TECHNICAL_CHANGES.md` peut ne pas etre cree — ne pas generer un fichier vide. A l'inverse, si le fichier existe deja et qu'il n'y a aucune entree technique pour cette release, simplement ne pas y ajouter de nouvelle section.
+
+### Cas 2 : le fichier existe
 
 Lire le contenu existant et :
 - Si **version specifiee** : creer une nouvelle section `[X.Y.Z] - YYYY-MM-DD` sous `[Unreleased]`, y deplacer les entrees, vider `[Unreleased]`
 - Si **pas de version** : inserer/mettre a jour les entrees dans `[Unreleased]`
 - Mettre a jour les liens de comparaison en bas du fichier
 
-### Regles communes
+### Regles communes aux deux fichiers
 
-- Respecter l'ordre impose des types : Added, Changed, Deprecated, Removed, Fixed, Security
+- Respecter l'ordre impose des types :
+  - CHANGELOG : `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
+  - TECHNICAL : `Refactor`, `Docs`, `Tests`, `CI`, `Dependencies`, `Chore`
 - Ne pas inclure les types sans entrees
-- Breaking changes prefixes par `**BREAKING**`
+- Breaking changes prefixes par `**BREAKING**` (CHANGELOG uniquement — pas de BREAKING technique)
 - Format de version `[MAJOR.MINOR.PATCH]` sans prefixe `v` dans les titres de section
 - En-tete de version : si le tag existe (map de l'etape 1), utiliser le lien inline `## [X.Y.Z](https://github.com/{owner}/{repo}/releases/tag/{tagRef}) - YYYY-MM-DD`. Si le tag n'existe pas, texte brut `## [X.Y.Z] - YYYY-MM-DD`. `[Unreleased]` n'est jamais linke.
 - Dates au format ISO 8601 (`YYYY-MM-DD`)
+- Memes versions, memes dates dans les deux fichiers : un tag git = une release, pas de desynchronisation
 
 ## Etape 4 — Afficher le resultat et confirmer
 
-Affiche le contenu complet du CHANGELOG genere (ou le diff si mise a jour).
+Affiche le contenu complet des fichiers generes (ou les diffs si mise a jour), dans deux blocs distincts et clairement identifies (`CHANGELOG.md` puis `TECHNICAL_CHANGES.md`). Si l'un des deux n'a pas de changement, le mentionner explicitement.
 
 Demande confirmation avant d'ecrire :
 
 ```
-Voici le CHANGELOG genere. Je l'ecris dans CHANGELOG.md ?
+Voici les fichiers generes. Je les ecris ?
+- CHANGELOG.md : [cree / mis a jour / inchange]
+- TECHNICAL_CHANGES.md : [cree / mis a jour / inchange]
 ```
 
 Une fois confirme :
-- Ecris le fichier
-- Commite avec le format : `📝 docs: mettre a jour le CHANGELOG` (ou `📝 docs: creer le CHANGELOG`)
+- Ecrire chaque fichier modifie
+- Commit unique regroupant les deux fichiers avec le format : `📝 docs: mettre a jour le CHANGELOG et le TECHNICAL_CHANGES` (ou `📝 docs: creer le CHANGELOG et le TECHNICAL_CHANGES` si premiere creation, ou `📝 docs: mettre a jour le CHANGELOG` si TECHNICAL inchange, etc. — adapter au scope reel)
 
 ## Etape 5 — Proposer la suite
 
 ```
 ---
-CHANGELOG mis a jour. Prochaine etape : `/pipe-pr` pour soumettre la branche.
+CHANGELOG et TECHNICAL_CHANGES mis a jour. Prochaine etape : `/pipe-pr` pour soumettre la branche.
 ```
 
 ---

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -41,18 +41,26 @@ Les types doivent toujours apparaitre dans cet ordre. Ne pas inclure les types s
 
 Pas de types custom (`Improved`, `Refactored`, `Chore`, etc.).
 
-## Mapping prefixe de commit → type CHANGELOG
+## Mapping prefixe de commit → fichier + type
 
-| Prefixe commit | Type CHANGELOG | Notes |
+Le classement se fait en deux fichiers : `CHANGELOG.md` (consommateur) et `TECHNICAL_CHANGES.md` (contributeur). Chaque commit retenu va dans **un seul** des deux.
+
+| Prefixe commit | Defaut | Exception (impact consommateur) |
 |---|---|---|
-| `feat` | Added | Nouvelle fonctionnalite |
-| `refactor` | Changed | Modification de comportement ou restructuration |
-| `perf` | Changed | Optimisation de performance |
-| `fix` | Fixed | Correction de bug |
-| `docs` | — | Exclure sauf si impact utilisateur (ex: nouveau guide public) |
-| `chore` | — | Exclure sauf si impact utilisateur (ex: changement de config publique) |
+| `feat` | CHANGELOG → `Added` | — |
+| `fix` | CHANGELOG → `Fixed` | — |
+| `perf` | CHANGELOG → `Changed` | — |
+| `refactor` | TECHNICAL → `Refactor` | CHANGELOG → `Changed` si l'API publique change |
+| `docs` | TECHNICAL → `Docs` | CHANGELOG → `Added`/`Changed` si doc user-facing (README public, doc API consommee) |
+| `chore` | TECHNICAL → `Chore`, `Dependencies` ou `CI` (voir ci-dessous) | CHANGELOG → `Changed` si config publique (`.mcp.json` exemple, manifest consomme) |
+| `test` | TECHNICAL → `Tests` | — |
 
-Cas speciaux (detectes par le contenu du commit, pas par le prefixe seul) :
+Sous-classement des `chore` dans TECHNICAL :
+- Bump de dependance → `Dependencies`
+- Modification d'un workflow CI, d'un hook git, d'un script de build → `CI`
+- Tout le reste (config interne, meta, scripts divers) → `Chore`
+
+Cas speciaux CHANGELOG (detectes par le contenu du commit, pas par le prefixe seul) :
 - Suppression explicite d'une fonctionnalite → `Removed`
 - Deprecation explicite → `Deprecated`
 - Patch de securite → `Security`
@@ -102,6 +110,70 @@ Si l'entree reformulee ne permet **pas** a un consommateur de repondre a l'une d
 - Est-ce que je dois adapter mon code ?
 - Quelle est la nouvelle valeur / le nouveau comportement ?
 
+## TECHNICAL_CHANGES.md — journal technique
+
+`TECHNICAL_CHANGES.md` est le pendant de `CHANGELOG.md` pour les contributeurs. Il capture les changements internes qui n'affectent pas le consommateur mais qui interessent un developpeur qui ouvre le repo : refactors, docs internes, tests, CI, bumps de deps, maintenance.
+
+### Symetrie avec CHANGELOG.md
+
+- Meme format Keep a Changelog + SemVer
+- Memes versions et memes dates (un tag git = une release, une seule date)
+- Meme mecanisme de liens de comparaison en bas de fichier
+- Meme regle de liens inline sur les en-tetes `## [X.Y.Z](tag-url) - YYYY-MM-DD` quand le tag existe
+
+### Types d'entrees (ordre impose)
+
+| Type | Usage |
+|---|---|
+| `Refactor` | Restructuration de code sans impact utilisateur (renommages internes, extraction de services, reorganisation de modules) |
+| `Docs` | Documentation interne (ADR, CONTRIBUTING, commentaires, README contributeur) |
+| `Tests` | Ajout, modification ou suppression de tests |
+| `CI` | Workflows, hooks git, pipelines de build, scripts d'automatisation |
+| `Dependencies` | Bumps de dependances (dev et runtime) |
+| `Chore` | Maintenance et config interne ne relevant d'aucune autre categorie |
+
+Pas de types custom hors de cette liste. Ne pas inclure les types sans entrees.
+
+### Structure globale
+
+```markdown
+# Technical Changes
+
+All notable technical changes targeted at contributors will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0](https://github.com/org/repo/releases/tag/v1.2.0) - 2026-03-29
+
+### Refactor
+
+- Extraction du service de detection de plateforme git dans `platform-detector` ([#18](https://github.com/org/repo/pull/18))
+
+### Dependencies
+
+- Bump `typescript` 5.3.0 → 5.4.2 ([`a1b2c3d`](https://github.com/org/repo/commit/a1b2c3d))
+
+[Unreleased]: https://github.com/org/repo/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/org/repo/compare/v1.1.0...v1.2.0
+```
+
+### Regles de contenu
+
+- Une entree = un changement technique notable **pour un contributeur** (pas pour l'utilisateur final)
+- Redigee de facon concise, orientee "ce qui a change dans le repo"
+- Chaque entree tient sur **une seule ligne** et inclut sa reference tracable (meme regle que CHANGELOG)
+- Ne jamais dupliquer une entree du CHANGELOG dans le TECHNICAL_CHANGES : un changement va **dans un seul** des deux fichiers
+- Les bumps de deps peuvent etre groupes : `Bump des dependances dev (typescript, vitest, biome) ([#N](url))` si la PR couvre plusieurs bumps liees
+
+### Cas limites
+
+- **Commit refactor qui prepare une feature user-facing** : l'entree va dans le CHANGELOG uniquement quand la feature est livree. Le refactor intermediaire, s'il est livre seul sans impact visible, va dans TECHNICAL.
+- **Docs qui impactent le consommateur** (ex: nouveau guide d'utilisation publique, doc d'API) : CHANGELOG, pas TECHNICAL.
+- **Update de doc contributeur** (CONTRIBUTING, ADR, README interne) : TECHNICAL, pas CHANGELOG.
+
 ## Coherence versions/dates
 
 Une entree placee sous une section versionnee `[X.Y.Z] - YYYY-MM-DD` doit correspondre a un commit (ou a une PR) **mergee avant la date du tag**. Un changement introduit apres la date de release appartient a `[Unreleased]`, jamais a une version deja publiee.
@@ -116,6 +188,8 @@ Lors de la generation ou de l'audit d'un CHANGELOG existant :
 4. Si la reference est **posterieure** a la date du tag, deplacer l'entree vers `[Unreleased]`.
 
 Cas typique : un CHANGELOG cree tardivement apres un premier tag, qui a absorbe par erreur des changements mergees plus tard. L'audit doit etre systematique a chaque passage de `/pipe-changelog`.
+
+Le meme audit s'applique a `TECHNICAL_CHANGES.md` : chaque entree sous une section versionnee doit referencer un commit/PR mergee avant la date du tag. Les deux fichiers sont audites a chaque passage du skill.
 
 ## References dans les entrees
 
@@ -197,14 +271,15 @@ Format :
 
 ## Exclusions
 
-Ne pas inclure dans le CHANGELOG :
+Exclus des deux fichiers (CHANGELOG et TECHNICAL) :
 
 - Les merges (`Merge branch...`, `Merge pull request...`)
 - Les rebases et fixups (`fixup!`, `squash!`)
-- Les changements de CI/CD internes
-- Les mises a jour de dependances mineures (sauf impact API publique)
-- Les typos de commentaires ou de docs internes
-- Le contenu des commits verbatim
+- Les typos purs (commentaires, fautes de frappe dans la doc)
+- Les commits de revert immediatement suivis du recommit
+- Le contenu des commits verbatim (toujours reformuler)
+
+Les changements CI/CD, les bumps de deps et les docs internes ne sont **pas** exclus : ils vont dans `TECHNICAL_CHANGES.md` (sections `CI`, `Dependencies`, `Docs`).
 
 ## Changesets (Turborepo) — optionnel
 


### PR DESCRIPTION
## Contexte

Ajout d'un journal technique `TECHNICAL_CHANGES.md` généré et maintenu en parallèle de `CHANGELOG.md` par le skill `/pipe-changelog`. Les commits techniques (refactor, docs internes, tests, CI, deps, chore) sont désormais capturés dans un fichier dédié aux contributeurs plutôt qu'exclus en silence.

## Ce qui a été fait

`/pipe-changelog` classe automatiquement chaque commit dans l'un des deux fichiers selon son préfixe : les changements user-facing (`feat`, `fix`, `perf`) vont dans `CHANGELOG.md`, les changements techniques (`refactor`, `docs`, `chore`, `test`) vont dans `TECHNICAL_CHANGES.md`. Les deux fichiers suivent le même format Keep a Changelog + SemVer (mêmes versions, mêmes dates, mêmes liens de comparaison).

## Fichiers modifiés

- `skills/pipe-changelog/SKILL.md` — étapes 2/2.5/3/4 adaptées pour gérer les deux fichiers en parallèle
- `skills/pipe-changelog/reference.md` — nouveau mapping préfixe → fichier + type, section TECHNICAL_CHANGES avec 6 types techniques, exclusions revues
- `TECHNICAL_CHANGES.md` — créé avec backfill de l'historique v1.0.0 → v1.4.2
- `CHANGELOG.md` — entrée `[Unreleased]` signalant le nouveau comportement

## Points de review

- Le classement `refactor` → TECHNICAL est le défaut ; exception si l'API publique change → CHANGELOG. Cette heuristique est documentée dans `reference.md` mais laisse une zone grise sur "qu'est-ce qu'une API publique" pour ce type de projet (skills = API implicite des utilisateurs).
- Le backfill de `TECHNICAL_CHANGES.md` est une reconstruction manuelle à partir des commits — non exhaustif, quelques commits techniques mineurs (`docs: mettre a jour le CHANGELOG`) ont été exclus volontairement.

## Tests

Skills testés manuellement sur ce repo lors de la session de travail ayant produit ce commit.