### PR TITLE
[Docs] Clarifier la convention CHANGELOG : une entree par information distincte (#41)

### DIFF
--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restructurer le skill `pipe-review` : le sub-agent produit 6 champs structures par probleme (fichier, severite, probleme_une_phrase, gravite_impact, cause, correction) et la phase 2 affiche chaque probleme en format Question/Reponse pedagogique avec exemple de rendu ([`c32e199`](https://github.com/ToolsForSaaS/claude-workflow/commit/c32e199))
 
+### Docs
+
+- Clarifier la convention de granularite dans `pipe-changelog` : une entree = une seule information user-facing distincte, principe #3 reformule pour distinguer fusion et decoupage, exemples Avant/Apres ajoutes ([`96b6a36`](https://github.com/ToolsForSaaS/claude-workflow/commit/96b6a36))
+
 ## [1.4.2](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.2) - 2026-04-14
 
 ### Docs

--- a/skills/pipe-changelog/SKILL.md
+++ b/skills/pipe-changelog/SKILL.md
@@ -60,6 +60,7 @@ Utilise Read pour charger `reference.md` (referentiel de conventions et mapping 
 6. **Reformuler** —
    - Pour CHANGELOG : appliquer les principes de la section "Rediger pour le consommateur" de `reference.md` (effet observable, valeurs concretes, fusion des entrees liees, impact client).
    - Pour TECHNICAL : entree concise orientee contributeur (ce qui a change dans le repo), meme regle d'une seule ligne et meme reference tracable.
+   - **Une entree = une seule information user-facing distincte** : si un changement couvre plusieurs aspects (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees (voir principe #3 dans `reference.md`).
    - Chaque entree tient sur **une seule ligne** et se termine par la reference entre parentheses avec un lien Markdown explicite (voir section "References dans les entrees" de `reference.md`). L'URL de base du remote est detectee a l'etape 1.
 
 Affiche les entrees classees avant de continuer, en deux blocs distincts :

--- a/skills/pipe-changelog/SKILL.md
+++ b/skills/pipe-changelog/SKILL.md
@@ -60,7 +60,7 @@ Utilise Read pour charger `reference.md` (referentiel de conventions et mapping 
 6. **Reformuler** —
    - Pour CHANGELOG : appliquer les principes de la section "Rediger pour le consommateur" de `reference.md` (effet observable, valeurs concretes, fusion des entrees liees, impact client).
    - Pour TECHNICAL : entree concise orientee contributeur (ce qui a change dans le repo), meme regle d'une seule ligne et meme reference tracable.
-   - **Une entree = une seule information user-facing distincte** : si un changement couvre plusieurs aspects (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees (voir principe #3 dans `reference.md`).
+   - **Une entree = une seule information user-facing distincte** : si un changement couvre plusieurs aspects (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees (principe #3 de la section "Rediger pour le consommateur" de `reference.md`).
    - Chaque entree tient sur **une seule ligne** et se termine par la reference entre parentheses avec un lien Markdown explicite (voir section "References dans les entrees" de `reference.md`). L'URL de base du remote est detectee a l'etape 1.
 
 Affiche les entrees classees avant de continuer, en deux blocs distincts :

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -68,7 +68,7 @@ Cas speciaux CHANGELOG (detectes par le contenu du commit, pas par le prefixe se
 
 ## Regles de contenu
 
-- Une entree = un changement notable cote utilisateur/consommateur
+- Une entree = **une seule information user-facing distincte**. Si un changement couvre plusieurs aspects distincts (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees plutot que de tout fusionner sur une ligne.
 - Redigee pour le lecteur, pas pour le dev — pas de detail d'implementation interne
 - Chaque entree tient sur **une seule ligne** — pas de retour a la ligne manuel au milieu d'une phrase. Les editeurs gerent le wrap, pas l'auteur.
 - Chaque entree inclut ses references tracables en fin de ligne (voir section "References dans les entrees")

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -83,7 +83,10 @@ Une entree de CHANGELOG parle au lecteur qui consomme le projet (dev qui appelle
 
 1. **Exposer l'effet observable** — codes HTTP, parametres accessibles, exigences cote client, comportement visible. Pas les noms de fonctions internes, decorateurs, hooks, ou refactors qui ne changent rien a l'usage.
 2. **Expliciter les valeurs concretes** — remplacer les formulations vagues par les contraintes reelles. "politique renforcee" → "minimum 12 caracteres avec majuscule, chiffre et symbole". "nouveau filtre" → "filtre `category_id` sur `GET /api/recipes`".
-3. **Fusionner les entrees liees** — plusieurs commits/PRs qui decrivent un **meme changement user-facing** (ex: ajout du cookie HttpOnly + marquage BREAKING + CORS credentials) deviennent une seule entree. Cote lecteur, c'est un seul evenement.
+3. **Fusionner les entrees liees, mais decouper les aspects distincts** — la fusion ne s'applique qu'aux commits/PRs qui decrivent **le meme evenement vu du consommateur** :
+   - ✅ **Fusion OK** : ajout du cookie HttpOnly + marquage BREAKING + CORS credentials → un seul evenement auth, donc une seule entree.
+   - ❌ **Fusion abusive** : nouveau champ obligatoire + nouveau filtre + nouvel endpoint + inclusion dans un GET → ce sont autant d'informations user-facing distinctes, chacune doit etre sa propre entree.
+   La regle : si le lecteur peut consommer un aspect sans connaitre les autres, c'est qu'il merite sa propre ligne.
 4. **Indiquer l'impact client quand il existe** — si le consommateur doit adapter son code (headers, options fetch, configuration), le dire explicitement dans l'entree.
 
 ### Avant / apres

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -105,6 +105,18 @@ Une entree de CHANGELOG parle au lecteur qui consomme le projet (dev qui appelle
 ✅ Politique de mot de passe renforcee a l'inscription : minimum 12 caracteres avec au moins une majuscule, un chiffre et un symbole
 ```
 
+#### Decoupage : plusieurs aspects user-facing distincts
+
+```
+❌ Ajout du champ `type` obligatoire sur POST, nouveau filtre `?type=` sur GET, nouvel endpoint `PATCH /pricing` et inclusion de `pricing` dans `GET /:id` (1 entree fourre-tout)
+
+✅ 4 entrees distinctes :
+   - **BREAKING** — `POST /recipes` : le champ `type` est desormais obligatoire (`'base'` ou `'composed'`)
+   - Nouveau filtre `?type=base|composed` sur `GET /recipes`
+   - `GET /recipes/:id` inclut un objet `pricing` quand les informations tarifaires sont renseignees
+   - Nouvel endpoint `PATCH /recipes/:id/pricing` (admin) pour creer ou mettre a jour le pricing
+```
+
 ### Heuristique rapide
 
 Si l'entree reformulee ne permet **pas** a un consommateur de repondre a l'une de ces questions, elle manque probablement de contenu :

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -83,10 +83,9 @@ Une entree de CHANGELOG parle au lecteur qui consomme le projet (dev qui appelle
 
 1. **Exposer l'effet observable** — codes HTTP, parametres accessibles, exigences cote client, comportement visible. Pas les noms de fonctions internes, decorateurs, hooks, ou refactors qui ne changent rien a l'usage.
 2. **Expliciter les valeurs concretes** — remplacer les formulations vagues par les contraintes reelles. "politique renforcee" → "minimum 12 caracteres avec majuscule, chiffre et symbole". "nouveau filtre" → "filtre `category_id` sur `GET /api/recipes`".
-3. **Fusionner les entrees liees, mais decouper les aspects distincts** — la fusion ne s'applique qu'aux commits/PRs qui decrivent **le meme evenement vu du consommateur** :
+3. **Fusionner les entrees liees, mais decouper les aspects distincts** — la regle : si le lecteur peut consommer un aspect sans connaitre les autres, c'est qu'il merite sa propre ligne. La fusion ne s'applique qu'aux commits/PRs qui decrivent **le meme evenement vu du consommateur** :
    - ✅ **Fusion OK** : ajout du cookie HttpOnly + marquage BREAKING + CORS credentials → un seul evenement auth, donc une seule entree.
    - ❌ **Fusion abusive** : nouveau champ obligatoire + nouveau filtre + nouvel endpoint + inclusion dans un GET → ce sont autant d'informations user-facing distinctes, chacune doit etre sa propre entree.
-   La regle : si le lecteur peut consommer un aspect sans connaitre les autres, c'est qu'il merite sa propre ligne.
 4. **Indiquer l'impact client quand il existe** — si le consommateur doit adapter son code (headers, options fetch, configuration), le dire explicitement dans l'entree.
 
 ### Avant / apres


### PR DESCRIPTION
## Contexte

La convention "Fusionner les entrees liees" (principe #3) etait sur-appliquee : des changements couvrant plusieurs aspects user-facing distincts se retrouvaient condenses sur une seule ligne illisible.

Closes #41

## Changements

- `reference.md` : la regle de granularite enonce explicitement "une entree = une seule information user-facing distincte" avec instruction de decouper si plusieurs aspects sont couverts
- `reference.md` : le principe #3 est reformule pour distinguer deux cas — fusion OK (meme evenement consommateur) vs decoupage obligatoire (aspects independamment consommables) — avec la regle de decision en tete des exemples
- `reference.md` : un bloc "Avant/Apres" avec l'exemple POST /recipes + pricing illustre concretement le decoupage en 4 entrees distinctes
- `SKILL.md` : la regle de granularite est rappelee dans l'etape 6 avec un renvoi correct vers le principe #3 de reference.md

## Tests

- Relecture manuelle : coherence entre SKILL.md et reference.md verifiee
- Aucune suite de tests automatisee sur ce projet (fichiers Markdown)