### PR TITLE
[Release] v1.4.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "description": "Pipeline AI-Driven Development : setup, plan, code, review, test, PR",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "author": {
     "name": "ToolsForSaaS"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.6] - 2026-04-23
+
+### Changed
+
+- `/pipe-review` présente maintenant chaque problème détecté en format Question/Réponse pédagogique avec 6 champs structurés (fichier, sévérité, description, impact, cause, correction) ([#42](https://github.com/ToolsForSaaS/claude-workflow/pull/42))
+
 ## [1.4.5] - 2026-04-17
 
 ### Changed
@@ -150,7 +156,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.6...HEAD
+[1.4.6]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.2...v1.4.3

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restructurer le skill `pipe-review` : le sub-agent produit 6 champs structures par probleme (fichier, severite, probleme_une_phrase, gravite_impact, cause, correction) et la phase 2 affiche chaque probleme en format Question/Reponse pedagogique avec exemple de rendu ([`c32e199`](https://github.com/ToolsForSaaS/claude-workflow/commit/c32e199))
 
+### Docs
+
+- Clarifier la convention de granularite dans `pipe-changelog` : une entree = une seule information user-facing distincte, principe #3 reformule pour distinguer fusion et decoupage, exemples Avant/Apres ajoutes ([`96b6a36`](https://github.com/ToolsForSaaS/claude-workflow/commit/96b6a36))
+
 ## [1.4.2](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.2) - 2026-04-14
 
 ### Docs

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactor
+
+- Restructurer le skill `pipe-review` : le sub-agent produit 6 champs structures par probleme (fichier, severite, probleme_une_phrase, gravite_impact, cause, correction) et la phase 2 affiche chaque probleme en format Question/Reponse pedagogique avec exemple de rendu ([`c32e199`](https://github.com/ToolsForSaaS/claude-workflow/commit/c32e199))
+
 ## [1.4.2](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.2) - 2026-04-14
 
 ### Docs

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.6] - 2026-04-23
+
 ### Refactor
 
-- Restructurer le skill `pipe-review` : le sub-agent produit 6 champs structures par probleme (fichier, severite, probleme_une_phrase, gravite_impact, cause, correction) et la phase 2 affiche chaque probleme en format Question/Reponse pedagogique avec exemple de rendu ([`c32e199`](https://github.com/ToolsForSaaS/claude-workflow/commit/c32e199))
+- Restructurer le skill `pipe-review` : le sub-agent produit 6 champs structurés par problème (fichier, sévérité, problème_une_phrase, gravité_impact, cause, correction) et la phase 2 affiche chaque problème en format Question/Réponse pédagogique avec exemple de rendu ([#42](https://github.com/ToolsForSaaS/claude-workflow/pull/42))
 
 ### Docs
 
-- Clarifier la convention de granularite dans `pipe-changelog` : une entree = une seule information user-facing distincte, principe #3 reformule pour distinguer fusion et decoupage, exemples Avant/Apres ajoutes ([`96b6a36`](https://github.com/ToolsForSaaS/claude-workflow/commit/96b6a36))
+- Clarifier la convention de granularité dans `pipe-changelog` : une entrée = une seule information user-facing distincte, principe #3 reformulé pour distinguer fusion et découpages, exemples Avant/Après ajoutés ([#43](https://github.com/ToolsForSaaS/claude-workflow/pull/43))
 
 ## [1.4.2](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.2) - 2026-04-14
 
@@ -101,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renommer le plugin et ajouter `.gitignore` ([`3f0423a`](https://github.com/ToolsForSaaS/claude-workflow/commit/3f0423a))
 - Supprimer le tableau de routage des skills et le template d'index devenus obsoletes ([`88ef12c`](https://github.com/ToolsForSaaS/claude-workflow/commit/88ef12c))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.6...HEAD
+[1.4.6]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...v1.4.6
 [1.4.2]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.3.3...v1.4.0

--- a/skills/pipe-changelog/SKILL.md
+++ b/skills/pipe-changelog/SKILL.md
@@ -60,6 +60,7 @@ Utilise Read pour charger `reference.md` (referentiel de conventions et mapping 
 6. **Reformuler** —
    - Pour CHANGELOG : appliquer les principes de la section "Rediger pour le consommateur" de `reference.md` (effet observable, valeurs concretes, fusion des entrees liees, impact client).
    - Pour TECHNICAL : entree concise orientee contributeur (ce qui a change dans le repo), meme regle d'une seule ligne et meme reference tracable.
+   - **Une entree = une seule information user-facing distincte** : si un changement couvre plusieurs aspects (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees (voir principe #3 dans `reference.md`).
    - Chaque entree tient sur **une seule ligne** et se termine par la reference entre parentheses avec un lien Markdown explicite (voir section "References dans les entrees" de `reference.md`). L'URL de base du remote est detectee a l'etape 1.
 
 Affiche les entrees classees avant de continuer, en deux blocs distincts :

--- a/skills/pipe-changelog/SKILL.md
+++ b/skills/pipe-changelog/SKILL.md
@@ -60,7 +60,7 @@ Utilise Read pour charger `reference.md` (referentiel de conventions et mapping 
 6. **Reformuler** —
    - Pour CHANGELOG : appliquer les principes de la section "Rediger pour le consommateur" de `reference.md` (effet observable, valeurs concretes, fusion des entrees liees, impact client).
    - Pour TECHNICAL : entree concise orientee contributeur (ce qui a change dans le repo), meme regle d'une seule ligne et meme reference tracable.
-   - **Une entree = une seule information user-facing distincte** : si un changement couvre plusieurs aspects (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees (voir principe #3 dans `reference.md`).
+   - **Une entree = une seule information user-facing distincte** : si un changement couvre plusieurs aspects (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees (principe #3 de la section "Rediger pour le consommateur" de `reference.md`).
    - Chaque entree tient sur **une seule ligne** et se termine par la reference entre parentheses avec un lien Markdown explicite (voir section "References dans les entrees" de `reference.md`). L'URL de base du remote est detectee a l'etape 1.
 
 Affiche les entrees classees avant de continuer, en deux blocs distincts :

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -68,7 +68,7 @@ Cas speciaux CHANGELOG (detectes par le contenu du commit, pas par le prefixe se
 
 ## Regles de contenu
 
-- Une entree = un changement notable cote utilisateur/consommateur
+- Une entree = **une seule information user-facing distincte**. Si un changement couvre plusieurs aspects distincts (nouveau champ + nouveau filtre + nouvel endpoint), decouper en autant d'entrees separees plutot que de tout fusionner sur une ligne.
 - Redigee pour le lecteur, pas pour le dev — pas de detail d'implementation interne
 - Chaque entree tient sur **une seule ligne** — pas de retour a la ligne manuel au milieu d'une phrase. Les editeurs gerent le wrap, pas l'auteur.
 - Chaque entree inclut ses references tracables en fin de ligne (voir section "References dans les entrees")

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -83,7 +83,10 @@ Une entree de CHANGELOG parle au lecteur qui consomme le projet (dev qui appelle
 
 1. **Exposer l'effet observable** — codes HTTP, parametres accessibles, exigences cote client, comportement visible. Pas les noms de fonctions internes, decorateurs, hooks, ou refactors qui ne changent rien a l'usage.
 2. **Expliciter les valeurs concretes** — remplacer les formulations vagues par les contraintes reelles. "politique renforcee" → "minimum 12 caracteres avec majuscule, chiffre et symbole". "nouveau filtre" → "filtre `category_id` sur `GET /api/recipes`".
-3. **Fusionner les entrees liees** — plusieurs commits/PRs qui decrivent un **meme changement user-facing** (ex: ajout du cookie HttpOnly + marquage BREAKING + CORS credentials) deviennent une seule entree. Cote lecteur, c'est un seul evenement.
+3. **Fusionner les entrees liees, mais decouper les aspects distincts** — la fusion ne s'applique qu'aux commits/PRs qui decrivent **le meme evenement vu du consommateur** :
+   - ✅ **Fusion OK** : ajout du cookie HttpOnly + marquage BREAKING + CORS credentials → un seul evenement auth, donc une seule entree.
+   - ❌ **Fusion abusive** : nouveau champ obligatoire + nouveau filtre + nouvel endpoint + inclusion dans un GET → ce sont autant d'informations user-facing distinctes, chacune doit etre sa propre entree.
+   La regle : si le lecteur peut consommer un aspect sans connaitre les autres, c'est qu'il merite sa propre ligne.
 4. **Indiquer l'impact client quand il existe** — si le consommateur doit adapter son code (headers, options fetch, configuration), le dire explicitement dans l'entree.
 
 ### Avant / apres

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -105,6 +105,18 @@ Une entree de CHANGELOG parle au lecteur qui consomme le projet (dev qui appelle
 ✅ Politique de mot de passe renforcee a l'inscription : minimum 12 caracteres avec au moins une majuscule, un chiffre et un symbole
 ```
 
+#### Decoupage : plusieurs aspects user-facing distincts
+
+```
+❌ Ajout du champ `type` obligatoire sur POST, nouveau filtre `?type=` sur GET, nouvel endpoint `PATCH /pricing` et inclusion de `pricing` dans `GET /:id` (1 entree fourre-tout)
+
+✅ 4 entrees distinctes :
+   - **BREAKING** — `POST /recipes` : le champ `type` est desormais obligatoire (`'base'` ou `'composed'`)
+   - Nouveau filtre `?type=base|composed` sur `GET /recipes`
+   - `GET /recipes/:id` inclut un objet `pricing` quand les informations tarifaires sont renseignees
+   - Nouvel endpoint `PATCH /recipes/:id/pricing` (admin) pour creer ou mettre a jour le pricing
+```
+
 ### Heuristique rapide
 
 Si l'entree reformulee ne permet **pas** a un consommateur de repondre a l'une de ces questions, elle manque probablement de contenu :

--- a/skills/pipe-changelog/reference.md
+++ b/skills/pipe-changelog/reference.md
@@ -83,10 +83,9 @@ Une entree de CHANGELOG parle au lecteur qui consomme le projet (dev qui appelle
 
 1. **Exposer l'effet observable** — codes HTTP, parametres accessibles, exigences cote client, comportement visible. Pas les noms de fonctions internes, decorateurs, hooks, ou refactors qui ne changent rien a l'usage.
 2. **Expliciter les valeurs concretes** — remplacer les formulations vagues par les contraintes reelles. "politique renforcee" → "minimum 12 caracteres avec majuscule, chiffre et symbole". "nouveau filtre" → "filtre `category_id` sur `GET /api/recipes`".
-3. **Fusionner les entrees liees, mais decouper les aspects distincts** — la fusion ne s'applique qu'aux commits/PRs qui decrivent **le meme evenement vu du consommateur** :
+3. **Fusionner les entrees liees, mais decouper les aspects distincts** — la regle : si le lecteur peut consommer un aspect sans connaitre les autres, c'est qu'il merite sa propre ligne. La fusion ne s'applique qu'aux commits/PRs qui decrivent **le meme evenement vu du consommateur** :
    - ✅ **Fusion OK** : ajout du cookie HttpOnly + marquage BREAKING + CORS credentials → un seul evenement auth, donc une seule entree.
    - ❌ **Fusion abusive** : nouveau champ obligatoire + nouveau filtre + nouvel endpoint + inclusion dans un GET → ce sont autant d'informations user-facing distinctes, chacune doit etre sa propre entree.
-   La regle : si le lecteur peut consommer un aspect sans connaitre les autres, c'est qu'il merite sa propre ligne.
 4. **Indiquer l'impact client quand il existe** — si le consommateur doit adapter son code (headers, options fetch, configuration), le dire explicitement dans l'entree.
 
 ### Avant / apres

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -140,7 +140,7 @@ Si l'utilisateur decline, propose `/pipe-test` et termine.
 
 Parcours chaque probleme dans l'ordre de severite (bloquants d'abord, puis avertissements, puis suggestions).
 
-Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique suivant**, en te basant sur les 6 champs produits par le sub-agent a l'etape 3. Relis le fichier concerne via Read avant l'affichage pour pouvoir montrer le code exact dans "D'ou ca vient ?" ou "Comment on corrige ?" si pertinent.
+Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique suivant**, en te basant sur les 6 champs produits par le sub-agent a l'etape 3.
 
 ```
 [Severite N/Total] — <fichier>:<ligne>
@@ -153,6 +153,7 @@ Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique s
 
 ❓ D'ou ca vient ?
    <cause>
+   [extrait de code pertinent si necessaire]
 
 ❓ Comment on corrige ?
    <correction>

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -66,11 +66,14 @@ Pour chaque fichier, cherche activement :
 - `any` injustifie, assertions forcees (`as`, `!`) sans garde
 - Props/parametres mal types, retours inconsistants
 
-Pour chaque probleme, donne :
-- Fichier et ligne
-- Severite : BLOQUANT (bug, faille, regression) / AVERTISSEMENT (dette significative) / SUGGESTION (lisibilite, robustesse)
-- Description en 1-2 phrases centree sur l'impact
-- Correction proposee
+Pour chaque probleme, produis ces 6 champs structures (utilises ensuite par la phase 2 du skill pour la revue interactive) :
+
+- **fichier** : chemin et ligne (ex: `src/services/user.service.ts:42`)
+- **severite** : BLOQUANT (bug, faille, regression) / AVERTISSEMENT (dette significative) / SUGGESTION (lisibilite, robustesse)
+- **probleme_une_phrase** : description courte du probleme, sans jargon. Doit etre comprehensible meme sans contexte technique
+- **gravite_impact** : consequence concrete pour l'utilisateur final, le code ou la donnee, avec une notion de frequence ou de risque (ex: "1 chargement sur 10 affiche les anciennes infos pendant 2 secondes" plutot que "violation du principe de coherence")
+- **cause** : cause technique en restant comprehensible — explique l'origine sans noyer le lecteur
+- **correction** : correction courte et actionnable, idealement avec un avant/apres tres bref
 
 **Ce que tu ne fais PAS :**
 - Pas de commentaire sur le style ou le formatting (c'est le role de Biome/ESLint)
@@ -78,7 +81,7 @@ Pour chaque probleme, donne :
 - Pas de compliments generiques
 - Pas de rapport exhaustif de tous les changements
 
-**Style** : ecris comme si tu parlais a un developpeur competent. Une phrase pour le probleme, une pour la correction — pas plus. L'impact doit etre immediatement comprehensible (ex: "ca peut crasher si X est null" plutot que "violation du principe de null-safety").
+**Style** : pour chacun des 6 champs, ecris comme si tu expliquais a un developpeur competent qui n'a pas tout le contexte en tete. L'impact doit etre exprime en termes concrets (consequence visible) et non en vocabulaire technique abstrait : preferer "ca peut crasher si X est null" a "violation du principe de null-safety". Une phrase par champ suffit.
 
 Produis un rapport structure avec statut global : OK, AVERTISSEMENTS, ou BLOQUANT.
 ```

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -140,16 +140,56 @@ Si l'utilisateur decline, propose `/pipe-test` et termine.
 
 Parcours chaque probleme dans l'ordre de severite (bloquants d'abord, puis avertissements, puis suggestions).
 
-Pour chaque probleme :
+Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique suivant**, en te basant sur les 6 champs produits par le sub-agent a l'etape 3. Relis le fichier concerne via Read avant l'affichage pour pouvoir montrer le code exact dans "D'ou ca vient ?" ou "Comment on corrige ?" si pertinent.
 
-1. **Explique en detail** : contexte, impact, code concerne (lis le fichier via Read pour montrer le code exact)
-2. **Propose la correction concrete** telle que decrite dans le rapport du sub-agent
-3. **Attends la decision de l'utilisateur** :
-   - **corriger** → relis d'abord le fichier via Read (les corrections precedentes ont pu modifier les lignes), puis applique la correction
-   - **adapter** → demande la modification souhaitee a l'utilisateur, relis le fichier via Read, puis applique
-   - **ignorer** → passe au probleme suivant sans rien modifier
+```
+[Severite N/Total] — <fichier>:<ligne>
+
+❓ Le probleme en une phrase
+   <probleme_une_phrase>
+
+❓ C'est grave ?
+   <gravite_impact>
+
+❓ D'ou ca vient ?
+   <cause>
+
+❓ Comment on corrige ?
+   <correction>
+
+→ corriger / adapter / ignorer ?
+```
+
+Puis **attends la decision de l'utilisateur** :
+
+- **corriger** → relis d'abord le fichier via Read (les corrections precedentes ont pu modifier les lignes), puis applique la correction
+- **adapter** → demande la modification souhaitee a l'utilisateur, relis le fichier via Read, puis applique
+- **ignorer** → passe au probleme suivant sans rien modifier
 
 Ne jamais corriger automatiquement sans validation explicite de l'utilisateur.
+
+#### Exemple de rendu
+
+```
+[Bloquant 1/3] — src/services/user.service.ts:42
+
+❓ Le probleme en une phrase
+   On notifie le client avant d'avoir fini d'enregistrer ses donnees.
+
+❓ C'est grave ?
+   Oui. Dans environ 1 cas sur 10, l'utilisateur verra l'ancienne
+   version de son profil juste apres l'avoir modifie.
+
+❓ D'ou ca vient ?
+   Un `await` oublie devant `saveCache(user)` : la notification
+   part immediatement, sans attendre la fin de l'ecriture en cache.
+
+❓ Comment on corrige ?
+   Ajouter `await` devant l'appel :
+   `await saveCache(user)` au lieu de `saveCache(user)`.
+
+→ corriger / adapter / ignorer ?
+```
 
 ### Cloture
 

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -140,6 +140,8 @@ Si l'utilisateur decline, propose `/pipe-test` et termine.
 
 Parcours chaque probleme dans l'ordre de severite (bloquants d'abord, puis avertissements, puis suggestions).
 
+`N/Total` = position du probleme dans la liste globale triee par severite, sur le nombre total de problemes toutes severites confondues (ex: si 2 bloquants + 1 suggestion, le premier bloquant est `1/3`, la suggestion est `3/3`).
+
 Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique suivant**, en te basant sur les 6 champs produits par le sub-agent a l'etape 3.
 
 ```

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -96,16 +96,16 @@ Affiche le rapport du sub-agent dans ce format :
 ### Statut : OK / Avertissements / Bloquant
 
 ### Problemes bloquants (a corriger avant de continuer)
-- `fichier.ts:42` description du probleme
-  → Correction proposee
+- `fichier.ts:42` <probleme_une_phrase>
+  → <correction>
 
 ### Avertissements
-- `fichier.ts:15` description
-  → Suggestion
+- `fichier.ts:15` <probleme_une_phrase>
+  → <correction>
 
 ### Suggestions
-- `fichier.ts:8` description
-  → Suggestion
+- `fichier.ts:8` <probleme_une_phrase>
+  → <correction>
 ```
 
 Si aucun probleme dans une categorie, ne pas afficher la section (pas de liste vide).


### PR DESCRIPTION
## Contexte

Mise à disposition de la version 1.4.6 du plugin `claude-workflow`.
Cette release regroupe les PRs #42 et #43 mergées sur `develop` depuis la v1.4.5.

## Ce qui a été fait

- **#42** : `/pipe-review` adopte un format Question/Réponse pédagogique avec 6 champs structurés par problème (fichier, sévérité, description, impact, cause, correction) — l'output visible de la review change
- **#43** : convention de granularité dans `pipe-changelog` clarifiée — une entrée = une seule information distincte, principe #3 reformulé avec exemples Avant/Après

CHANGELOG, TECHNICAL_CHANGES et `plugin.json` sont à jour pour la v1.4.6.

## Fichiers modifiés

- `skills/pipe-review/SKILL.md` — format Q/R et 6 champs structurés
- `skills/pipe-changelog/SKILL.md` — règle de granularité renforcée
- `skills/pipe-changelog/reference.md` — exemples Avant/Après ajoutés
- `CHANGELOG.md` — section 1.4.6 ajoutée
- `TECHNICAL_CHANGES.md` — section 1.4.6 ajoutée
- `.claude-plugin/plugin.json` — version bump 1.4.5 → 1.4.6

## Points de review

Pas de breaking change. Changements comportementaux dans deux skills existants.

## Tests

Skills validés via les PRs #42 et #43 avant merge sur `develop`.