### PR TITLE
[Refactor] Simplifier et contextualiser les questions de la revue interactive (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.7] - 2026-04-27
+### Changed
+
+- `/pipe-review` enrichit la revue interactive avec une question de contexte fonctionnel ("De quoi on parle ?") en tete de chaque probleme, reformule les descriptions sans jargon technique et inclut le contexte dans le rapport de synthese ([`72a4cec`](https://github.com/ToolsForSaaS/claude-workflow/commit/72a4cec))
+
+## [1.4.7](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.7) - 2026-04-27
 
 ### Changed
 
@@ -163,7 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.6...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.7...HEAD
+[1.4.7]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.6...v1.4.7
 [1.4.6]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.3...v1.4.4

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.7] - 2026-04-27
+## [1.4.7](https://github.com/ToolsForSaaS/claude-workflow/releases/tag/v1.4.7) - 2026-04-27
 
 ### Docs
 
@@ -110,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renommer le plugin et ajouter `.gitignore` ([`3f0423a`](https://github.com/ToolsForSaaS/claude-workflow/commit/3f0423a))
 - Supprimer le tableau de routage des skills et le template d'index devenus obsoletes ([`88ef12c`](https://github.com/ToolsForSaaS/claude-workflow/commit/88ef12c))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.6...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.7...HEAD
+[1.4.7]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.6...v1.4.7
 [1.4.6]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.5...v1.4.6
 [1.4.2]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.0...v1.4.1

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -143,10 +143,13 @@ Parcours chaque probleme dans l'ordre de severite (bloquants d'abord, puis avert
 
 `N/Total` = position du probleme dans la liste globale triee par severite, sur le nombre total de problemes toutes severites confondues (ex: si 2 bloquants + 1 suggestion, le premier bloquant est `1/3`, la suggestion est `3/3`).
 
-Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique suivant**, en te basant sur les 6 champs produits par le sub-agent a l'etape 3.
+Pour chaque probleme, **affiche-le dans le format Question/Reponse pedagogique suivant**, en te basant sur les 7 champs produits par le sub-agent a l'etape 3.
 
 ```
 [Severite N/Total] — <fichier>:<ligne>
+
+❓ De quoi on parle ?
+   <contexte_fonctionnel>
 
 ❓ Le probleme en une phrase
    <probleme_une_phrase>

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -66,14 +66,15 @@ Pour chaque fichier, cherche activement :
 - `any` injustifie, assertions forcees (`as`, `!`) sans garde
 - Props/parametres mal types, retours inconsistants
 
-Pour chaque probleme, produis ces 6 champs structures (utilises ensuite par la phase 2 du skill pour la revue interactive) :
+Pour chaque probleme, produis ces 7 champs structures (utilises ensuite par la phase 2 du skill pour la revue interactive) :
 
 - **fichier** : chemin et ligne (ex: `src/services/user.service.ts:42`)
 - **severite** : BLOQUANT (bug, faille, regression) / AVERTISSEMENT (dette significative) / SUGGESTION (lisibilite, robustesse)
-- **probleme_une_phrase** : description courte du probleme, sans jargon. Doit etre comprehensible meme sans contexte technique
-- **gravite_impact** : consequence concrete pour l'utilisateur final, le code ou la donnee, avec une notion de frequence ou de risque (ex: "1 chargement sur 10 affiche les anciennes infos pendant 2 secondes" plutot que "violation du principe de coherence")
-- **cause** : cause technique en restant comprehensible — explique l'origine sans noyer le lecteur
-- **correction** : correction courte et actionnable, idealement avec un avant/apres tres bref
+- **contexte_fonctionnel** : 1-2 phrases qui resituent le bout de code dans le parcours utilisateur ou le flux metier. Reponds a "qui appelle ce code, dans quelle situation, pour faire quoi ?" en langage du domaine. Pas de noms de fonctions, pas de tags XML/HTML, pas de jargon technique. Si le contexte n'est pas inferrable depuis le diff et les fichiers lus, ecris explicitement "Contexte non identifie depuis le diff" plutot que d'inventer
+- **probleme_une_phrase** : reformulation **fonctionnelle** du probleme, comprehensible sans le code. **Interdit** : noms de fonctions ou variables, tags XML/HTML, syntaxe de code, noms de types. Exemple : "Si la reponse du logiciel de caisse est incomplete, on continue comme si tout allait bien" et non "La garde `single.children.length > 0` accepte un `<resultCustomerType>` sans `<id>`"
+- **gravite_impact** : la **premiere phrase** doit decrire une consequence concrete et observable cote utilisateur final ou metier (ce qu'il voit, perd, risque). Les nuances de frequence et le contexte technique viennent ensuite. Exemple : "L'utilisateur en caisse verrait un ecran de confirmation avec un numero de carte vide. Cas rare en pratique, mais sans message d'erreur le caissier n'a aucun moyen de comprendre ce qui s'est passe"
+- **cause** : explication accessible de l'origine. **Prefere** "le code", "la verification", "la fonction qui parse la reponse" plutot que les noms exacts de symboles. Ne nomme un symbole precis que si c'est indispensable pour pointer le bon endroit
+- **correction** : commence par une **phrase d'introduction fonctionnelle** ("Verifier que la reponse contient bien un numero de carte avant de continuer") puis donne la directive technique courte et actionnable, avec un avant/apres tres bref si pertinent
 
 **Ce que tu ne fais PAS :**
 - Pas de commentaire sur le style ou le formatting (c'est le role de Biome/ESLint)
@@ -81,7 +82,7 @@ Pour chaque probleme, produis ces 6 champs structures (utilises ensuite par la p
 - Pas de compliments generiques
 - Pas de rapport exhaustif de tous les changements
 
-**Style** : pour chacun des 6 champs, ecris comme si tu expliquais a un developpeur competent qui n'a pas tout le contexte en tete. L'impact doit etre exprime en termes concrets (consequence visible) et non en vocabulaire technique abstrait : preferer "ca peut crasher si X est null" a "violation du principe de null-safety". Une phrase par champ suffit.
+**Style** : pour chacun des 7 champs, ecris comme si tu expliquais a quelqu'un qui n'a **pas** le code sous les yeux — un decideur produit, un dev qui reprend le projet la semaine prochaine, ou toi-meme dans 6 mois. L'impact doit etre exprime en termes concrets (consequence visible) et non en vocabulaire technique abstrait : preferer "ca peut crasher si X est null" a "violation du principe de null-safety". Une a deux phrases par champ suffisent.
 
 Produis un rapport structure avec statut global : OK, AVERTISSEMENTS, ou BLOQUANT.
 ```

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -180,20 +180,29 @@ Ne jamais corriger automatiquement sans validation explicite de l'utilisateur.
 ```
 [Bloquant 1/3] — src/services/user.service.ts:42
 
+❓ De quoi on parle ?
+   De la modification du profil utilisateur. Quand l'utilisateur
+   enregistre des changements, on met a jour la base, on rafraichit
+   le cache, puis on lui confirme que c'est sauvegarde pour qu'il
+   voie les bonnes infos sur les ecrans suivants.
+
 ❓ Le probleme en une phrase
-   On notifie le client avant d'avoir fini d'enregistrer ses donnees.
+   On confirme la sauvegarde a l'utilisateur avant que le cache
+   soit reellement a jour.
 
 ❓ C'est grave ?
-   Oui. Dans environ 1 cas sur 10, l'utilisateur verra l'ancienne
-   version de son profil juste apres l'avoir modifie.
+   L'utilisateur verra l'ancienne version de son profil juste apres
+   l'avoir modifie. Ca se produit environ 1 fois sur 10 selon la
+   charge, et il faut recharger la page pour voir les bonnes infos.
 
 ❓ D'ou ca vient ?
-   Un `await` oublie devant `saveCache(user)` : la notification
-   part immediatement, sans attendre la fin de l'ecriture en cache.
+   Le code lance le rafraichissement du cache mais n'attend pas
+   sa fin avant d'envoyer la confirmation. Un mot-cle d'attente
+   est manquant a cet endroit precis.
 
 ❓ Comment on corrige ?
-   Ajouter `await` devant l'appel :
-   `await saveCache(user)` au lieu de `saveCache(user)`.
+   Attendre la fin du rafraichissement du cache avant de notifier
+   l'utilisateur : ajouter `await` devant l'appel a `saveCache(user)`.
 
 → corriger / adapter / ignorer ?
 ```

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -71,10 +71,10 @@ Pour chaque probleme, produis ces 7 champs structures (utilises ensuite par la p
 - **fichier** : chemin et ligne (ex: `src/services/user.service.ts:42`)
 - **severite** : BLOQUANT (bug, faille, regression) / AVERTISSEMENT (dette significative) / SUGGESTION (lisibilite, robustesse)
 - **contexte_fonctionnel** : 1-2 phrases qui resituent le bout de code dans le parcours utilisateur ou le flux metier. Reponds a "qui appelle ce code, dans quelle situation, pour faire quoi ?" en langage du domaine. Pas de noms de fonctions, pas de tags XML/HTML, pas de jargon technique. Si le contexte n'est pas inferrable depuis le diff et les fichiers lus, ecris explicitement "Contexte non identifie depuis le diff" plutot que d'inventer
-- **probleme_une_phrase** : reformulation **fonctionnelle** du probleme, comprehensible sans le code. **Interdit** : noms de fonctions ou variables, tags XML/HTML, syntaxe de code, noms de types. Exemple : "Si la reponse du logiciel de caisse est incomplete, on continue comme si tout allait bien" et non "La garde `single.children.length > 0` accepte un `<resultCustomerType>` sans `<id>`"
+- **probleme_une_phrase** : reformulation **fonctionnelle** du probleme, comprehensible sans le code. **Interdit dans ce champ** : noms de fonctions ou variables, tags XML/HTML, syntaxe de code, noms de types. Exemple : "Si la reponse du logiciel de caisse est incomplete, on continue comme si tout allait bien" et non "La garde `single.children.length > 0` accepte un `<resultCustomerType>` sans `<id>`"
 - **gravite_impact** : la **premiere phrase** doit decrire une consequence concrete et observable cote utilisateur final ou metier (ce qu'il voit, perd, risque). Les nuances de frequence et le contexte technique viennent ensuite. Exemple : "L'utilisateur en caisse verrait un ecran de confirmation avec un numero de carte vide. Cas rare en pratique, mais sans message d'erreur le caissier n'a aucun moyen de comprendre ce qui s'est passe"
 - **cause** : explication accessible de l'origine. **Prefere** "le code", "la verification", "la fonction qui parse la reponse" plutot que les noms exacts de symboles. Ne nomme un symbole precis que si c'est indispensable pour pointer le bon endroit
-- **correction** : commence par une **phrase d'introduction fonctionnelle** ("Verifier que la reponse contient bien un numero de carte avant de continuer") puis donne la directive technique courte et actionnable, avec un avant/apres tres bref si pertinent
+- **correction** : commence par une **phrase d'introduction fonctionnelle** ("Verifier que la reponse contient bien un numero de carte avant de continuer") puis donne la directive technique courte et actionnable, avec un avant/apres tres bref si pertinent. **Les noms de symboles sont autorises et souvent necessaires ici** pour pointer le fix exact (`saveCache`, `await`, type `Customer`, etc.) — l'interdiction posee sur `probleme_une_phrase` ne s'applique pas a ce champ ni a `cause`
 
 **Ce que tu ne fais PAS :**
 - Pas de commentaire sur le style ou le formatting (c'est le role de Biome/ESLint)
@@ -82,7 +82,12 @@ Pour chaque probleme, produis ces 7 champs structures (utilises ensuite par la p
 - Pas de compliments generiques
 - Pas de rapport exhaustif de tous les changements
 
-**Style** : pour chacun des 7 champs, ecris comme si tu expliquais a quelqu'un qui n'a **pas** le code sous les yeux — un decideur produit, un dev qui reprend le projet la semaine prochaine, ou toi-meme dans 6 mois. L'impact doit etre exprime en termes concrets (consequence visible) et non en vocabulaire technique abstrait : preferer "ca peut crasher si X est null" a "violation du principe de null-safety". Une a deux phrases par champ suffisent.
+**Style** : deux audiences selon les champs.
+
+- `contexte_fonctionnel`, `probleme_une_phrase`, `gravite_impact` s'adressent a quelqu'un qui n'a **pas** le code sous les yeux — un decideur produit, un dev qui reprend le projet la semaine prochaine, ou toi-meme dans 6 mois. Vocabulaire fonctionnel, consequence visible plutot qu'abstraction technique : preferer "ca peut crasher si X est null" a "violation du principe de null-safety".
+- `cause` et `correction` s'adressent au developpeur qui va corriger dans la foulee. Reste precis et actionnable, nomme les symboles quand c'est necessaire.
+
+Une a deux phrases par champ suffisent.
 
 Produis un rapport structure avec statut global : OK, AVERTISSEMENTS, ou BLOQUANT.
 ```
@@ -98,14 +103,17 @@ Affiche le rapport du sub-agent dans ce format :
 
 ### Problemes bloquants (a corriger avant de continuer)
 - `fichier.ts:42` <probleme_une_phrase>
+  · <contexte_fonctionnel>
   → <correction>
 
 ### Avertissements
 - `fichier.ts:15` <probleme_une_phrase>
+  · <contexte_fonctionnel>
   → <correction>
 
 ### Suggestions
 - `fichier.ts:8` <probleme_une_phrase>
+  · <contexte_fonctionnel>
   → <correction>
 ```
 


### PR DESCRIPTION
## Contexte

Closes #48

La Phase 2 de `/pipe-review` presentait les problemes sans contexte fonctionnel : on attaquait la cause technique sans poser le decor, et l'impact metier etait noye dans du jargon. Sans le code sous les yeux, difficile de juger la pertinence d'un probleme.

## Changements

- Ajoute un champ `contexte_fonctionnel` dans le prompt du sub-agent (etape 3) : 1-2 phrases qui resituent le code dans le parcours utilisateur, en langage du domaine
- Reformule les consignes de style sur `probleme_une_phrase` (interdit : noms de fonctions, tags XML, syntaxe), `gravite_impact` (1re phrase = consequence visible utilisateur), `cause` (accessibilite avant precision), `correction` (intro fonctionnelle avant la directive technique)
- Ajoute la question "De quoi on parle ?" en tete du bloc Q/R en Phase 2
- Inclut le contexte fonctionnel dans le rapport de synthese (etape 4)
- Clarifie la portee de l'interdiction des noms de symboles (limitee a `probleme_une_phrase` et `contexte_fonctionnel`)
- Distingue deux audiences dans la section Style : impact/contexte pour quelqu'un sans le code, cause/correction pour le dev qui va agir
- Met a jour l'exemple de rendu pour illustrer le nouveau format a 5 questions