### PR TITLE
[Release] v1.6.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "description": "Pipeline AI-Driven Development : setup, plan, code, review, test, changelog, PR, tag",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "ToolsForSaaS"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-30
+
+### Changed
+
+- `/pipe-ship <ticket>` démarre le cycle quand le ticket n'a pas encore de pilotage, au lieu de proposer `/pipe-spec` et de rendre la main : c'est la commande d'entrée autant que de reprise, et la phase de cadrage n'est plus l'exception à retenir ([`3c260d4`](https://github.com/ToolsForSaaS/claude-workflow/commit/3c260d4))
+
 ## [1.6.0] - 2026-07-30
 
 ### Added
@@ -251,7 +257,8 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.9...v1.5.0
 [1.4.9]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.8...v1.4.9

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Quand une feature est **retiree**, sa spec ne se corrige pas : elle passe au sta
 
 **Projet existant ?** `/pipe-spec` sans argument inventorie les features deja livrees, les classe par valeur (les zones les plus retouchees du `git log` sont celles qu'on relira le plus) et en cadre une par passe. Sans ce rattrapage, les specs n'arriveraient qu'au rythme des futurs tickets — donc jamais pour le code deja ecrit.
 
-`/pipe-ship <ticket>` est la commande de reprise : dans chaque session, elle lit le pilotage, detecte la phase courante et deroule jusqu'a la prochaine pause humaine ou frontiere de session. Chaque etape reste invocable individuellement.
+`/pipe-ship <ticket>` est la commande de reprise : dans chaque session, elle lit le pilotage, detecte la phase courante et deroule jusqu'a la prochaine pause humaine ou frontiere de session. Sur un ticket qui n'a pas encore de pilotage, elle demarre le cycle par le cadrage — c'est donc aussi la commande d'entree, pas seulement de reprise. Chaque etape reste invocable individuellement.
 
 Quand assez de features sont mergees sur la branche d'integration :
 

--- a/docs/specs/reprise-de-cycle.md
+++ b/docs/specs/reprise-de-cycle.md
@@ -20,7 +20,8 @@ Reussi quand reprendre un ticket ne demande de se rappeler ni la phase, ni la co
 ## Comportement attendu
 
 - Sans argument, un cycle unique est pris automatiquement ; plusieurs cycles ouverts declenchent une question
-- Aucun cycle en cours propose de demarrer par le cadrage, et s'arrete la
+- Aucun cycle en cours ouvre le cadrage, qui creera le pilotage : la commande est un point d'entree autant qu'une reprise
+- Demarrer un cycle exige un ticket ou un nom de feature : sans lui, il est demande avant d'enchainer
 - La phase courante est la premiere etape non validee du pilotage, jamais une deduction depuis l'etat du code
 - La phase est annoncee avant d'etre executee : ticket, branche, ce qui va se passer
 - Les phases s'enchainent tant qu'aucune frontiere de session n'est franchie
@@ -55,6 +56,7 @@ Deux phases exigent un contexte neuf : l'implementation et la review. La frontie
 |---------|--------|----------|--------|---------------------|
 | — | — | La phase se lit dans le pilotage, pas dans l'etat du repo | Une branche poussee ou une suite verte ne disent pas si un humain a valide : seule une case cochee le dit | Deduire la phase du code et de git |
 | — | — | Aucune logique metier ici | Une regle dupliquee entre ce skill et celui de la phase divergerait au premier changement, et le doublon silencieux serait le pire cas | Recopier les verifications de chaque phase |
+| — | — | Un cycle absent est ouvert plutot qu'annonce | La commande est censee etre le seul geste a retenir : renvoyer vers une autre commande pour la seule phase de depart en fait une exception a memoriser | Proposer le cadrage et rendre la main |
 | — | — | La frontiere de session ne s'applique qu'en enchainement | Bloquer aussi un lancement en debut de session rendrait la reprise impossible precisement quand elle est legitime | Bloquer inconditionnellement |
 
 ## Points d'entree
@@ -67,5 +69,6 @@ Deux phases exigent un contexte neuf : l'implementation et la review. La frontie
 ## Pieges et zones sensibles
 
 - **La table etat → skill est couplee a l'ordre des cases du pilotage** : ajouter une phase sans toucher les deux rend la nouvelle etape inatteignable, sans erreur visible
+- **Le cadrage sans argument ne demarre pas un cycle mais l'inventaire des specs existantes** : d'ou le ticket exige avant d'y router
 - **Une case cochee en avance saute definitivement sa phase** : rien ne revient en arriere, la reprise fait confiance a l'etat declare
 - Le pilotage doit avoir ete supprime a la creation de la Pull Request : sinon la reprise repart sur un cycle deja livre

--- a/skills/pipe-ship/SKILL.md
+++ b/skills/pipe-ship/SKILL.md
@@ -10,11 +10,11 @@ Ce skill n'a pas de logique propre : il localise le pilotage, identifie la phase
 
 - Argument fourni → `.claude/plans/plan-<identifiant>.md`
 - Sans argument → cherche `.claude/plans/plan-*.md` : un seul fichier → le prendre ; plusieurs → demander lequel
-- Aucun pilotage → pas de cycle en cours : propose de demarrer par le cadrage, `/pipe-spec [ticket]` (c'est lui qui ouvre le pilotage), et arrete-toi
+- Aucun pilotage → le cycle n'a pas encore commence : c'est le cadrage qui l'ouvrira. Va directement a la phase `Spec a jour` de l'etape 2, avec l'argument recu comme ticket. Sans argument, demande d'abord le ticket ou le nom de la feature : ne charge jamais `/pipe-spec` sans argument depuis ici, ce declencheur ouvre le mode inventaire, qui n'est pas un cycle
 
 ## Etape 1 — Identifier la phase courante
 
-Lis le pilotage en entier. Dans la section Etat, la **premiere case non cochee** donne la phase courante. Annonce en une ligne : ticket, branche, phase courante, ce qui va se passer.
+Lis le pilotage en entier. Dans la section Etat, la **premiere case non cochee** donne la phase courante. Sans pilotage, la phase courante est le cadrage. Annonce en une ligne : ticket, branche, phase courante, ce qui va se passer.
 
 ## Etape 2 — Derouler
 


### PR DESCRIPTION
Release **v1.6.1** — `develop` → `main`.

## Changements

### Changed

- `/pipe-ship <ticket>` démarre le cycle quand le ticket n'a pas encore de pilotage, au lieu de proposer `/pipe-spec` et de rendre la main : c'est la commande d'entrée autant que de reprise, et la phase de cadrage n'est plus l'exception à retenir (`3c260d4`)

## Commits inclus

Aucune PR de feature dans cette release — deux commits directs sur `develop` :

- `3c260d4` ✨ feat(pipe-ship): demarrer le cycle quand aucun pilotage n'existe
- `f18b844` 🔧 chore(release): preparer la version 1.6.1

## Version

`plugin.json` : **1.6.1** (`bump-version.sh`). Version notée en PATCH sur demande explicite, alors que le commit livré est un `feat` — SemVer aurait donné 1.7.0.

Après merge et déploiement : `/pipe-tag v1.6.1` sur `main`.
