### PR TITLE
[Release] v1.6.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "description": "Pipeline AI-Driven Development : setup, plan, code, review, test, changelog, PR, tag",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": {
     "name": "ToolsForSaaS"
   }

--- a/.claude/skills/create-skill/guide.md
+++ b/.claude/skills/create-skill/guide.md
@@ -144,6 +144,18 @@ $ARGUMENTS
 | Contexte dynamique `!`cmd`` | `allowed-tools` avec les patterns Bash necessaires (ex: `Bash(git *)`, `Bash(gh *)`, `Bash(ls *)`) |
 | Depasse ~150 lignes | Se demander quoi deleguer dans `reference.md` |
 
+## Grammaire de sortie
+
+Ce que le skill affiche a l'utilisateur est aussi une interface. Elle est **dense par defaut** : un skill qui deroule des paragraphes fait relire a chaque invocation ce qui tenait sur trois lignes.
+
+- **Une ligne de statut en tete**, jamais un en-tete suivi d'un blanc puis d'une metrique : `**Dev termine — PROJ-42** · tests ✅ 34 passent`
+- **Un fait par ligne**, libelle en gras puis tiret cadratin : `**Impact** — ...`. Les questions ouvertes (`❓ C'est grave ?`) et les listes a deux niveaux sont du remplissage
+- **Ne jamais afficher ce que l'utilisateur a deja sous les yeux** : sortie d'une commande, contenu d'un fichier qu'on vient de lui montrer, recap deja affiche a une etape precedente
+- **Aucune phrase d'introduction ni de transition** (« Voici… », « Je vais maintenant… », « Parfait, passons a… »)
+- **Tableau des qu'il y a trois colonnes de faits**, liste a puces sinon, prose jamais
+- **Fin d'etape = une ligne** : `Suite : <geste> — /commande`. Un bloc de trois lignes pour dire quoi taper est deux lignes de trop
+- Le detail que l'utilisateur veut vraiment, il le demande. L'afficher par defaut le fait payer a tout le monde
+
 ## Regles strictes
 
 - `## Contexte` avec `!`cmd`` en tete **quand** des donnees d'environnement conditionnent les etapes — section optionnelle, la majorite des skills n'en a pas besoin. Un contexte dynamique qu'aucune etape n'exploite coute une commande shell a chaque invocation pour rien

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-07-30
+
+### Changed
+
+- Les skills du pipeline affichent des sorties compactes : une ligne de statut plutôt qu'un titre suivi d'une métrique, un fait par ligne, et plus de récapitulatif répété d'une étape à l'autre. Le rapport de review passe de 22 à 8 lignes par constat, sans rien perdre de son contenu ([`19bc699`](https://github.com/alex-robert-fr/claude-workflow/commit/19bc699))
+
 ## [1.6.1] - 2026-07-30
 
 ### Changed
@@ -257,7 +263,8 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.2...HEAD
+[1.6.2]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.4.9...v1.5.0

--- a/skills/pipe-changelog/SKILL.md
+++ b/skills/pipe-changelog/SKILL.md
@@ -41,12 +41,10 @@ Recupere les informations necessaires :
 Affiche le contexte detecte :
 
 ```
-Contexte de versioning :
-- Dernier tag : [tag ou "aucun"]
-- Remote : [URL HTTPS]
-- Phase : [pre-v1.0.0 / post-v1.0.0]
-- Cible : [version ou "Unreleased"]
+Versioning — dernier tag [tag ou "aucun"] · [pre-v1.0.0 / post-v1.0.0] · cible [version ou "Unreleased"]
 ```
+
+Le remote sert aux liens, il n'a pas a etre affiche.
 
 ## Etape 2 — Collecter les changements
 
@@ -72,7 +70,7 @@ Utilise Read pour charger `${CLAUDE_SKILL_DIR}/reference.md` (referentiel de con
 Affiche les entrees classees avant de continuer :
 
 ```
-Changements detectes :
+**Changements detectes**
 
 ### Added
 - [entree courte reformulee] ([#15](url/pull/15))
@@ -154,8 +152,7 @@ Affiche le contenu complet du fichier en creation (Cas 1), le diff seul en mise 
 Demande confirmation avant d'ecrire :
 
 ```
-Voici le CHANGELOG genere. Je l'ecris ?
-- CHANGELOG.md : [cree / mis a jour]
+J'ecris `CHANGELOG.md` ([cree / mis a jour]) ?
 ```
 
 Une fois confirme :
@@ -166,7 +163,7 @@ Une fois confirme :
 
 ```
 ---
-CHANGELOG mis a jour. En contexte release : retour a `/pipe-release` (PR vers la branche de production).
+CHANGELOG mis a jour. En contexte release : retour a `/pipe-release`.
 ```
 
 ---

--- a/skills/pipe-code/SKILL.md
+++ b/skills/pipe-code/SKILL.md
@@ -50,25 +50,18 @@ Une fois tous les tests verts :
 - Affiche le recap :
 
 ```
-## Implementation terminee — [ticket]
+**Dev termine — [ticket]** · tests ✅ N passent (dont M nouveaux)
 
-Tests : ✅ N passent (dont M nouveaux)
-
-### Commits crees (le reste attend /pipe-commit)
+Commits crees (le reste attend `/pipe-commit`) :
 - emoji type(scope): description
 
-### Fichiers crees
-- chemin/fichier.ts
+Fichiers — `+ chemin/nouveau.ts` · `~ chemin/modifie.ts`
 
-### Fichiers modifies
-- chemin/fichier.ts
-```
-
-```
 ---
-Phase suivante : la review, dans une NOUVELLE session :
-ouvre une session et lance `/pipe-ship [ticket]` (ou `/pipe-review [ticket]`).
+Suite : la review, dans une **nouvelle session** — `/pipe-ship [ticket]`.
 ```
+
+`+` pour un fichier cree, `~` pour un fichier modifie : deux sections separees pour la meme information, c'est une section de trop.
 
 ---
 

--- a/skills/pipe-commit/SKILL.md
+++ b/skills/pipe-commit/SKILL.md
@@ -49,7 +49,7 @@ Coche `Commits crees` dans le pilotage.
 
 ```
 ---
-N commits crees. Phase suivante : `/pipe-pr [ticket]` pour creer la Pull Request.
+N commits crees. Suite : `/pipe-pr [ticket]`.
 ```
 
 ## Mode simple (commit ponctuel)
@@ -69,14 +69,10 @@ Committe directement, sans demander confirmation — un commit local est reversi
 Affiche le recap apres coup :
 
 ```
-Commit cree :
-
-emoji type(scope): description
-
+**Commit cree** — emoji type(scope): description
 - [puce du body si present]
 
-Fichiers :
-- chemin/fichier.ts
+Fichiers — `chemin/fichier.ts`
 ```
 
 ### Etape 3 — Push (optionnel)

--- a/skills/pipe-plan/SKILL.md
+++ b/skills/pipe-plan/SKILL.md
@@ -120,9 +120,8 @@ Presente le plan a l'utilisateur. Coche `Plan valide` dans l'etat **uniquement a
 
 ```
 ---
-Plan valide, pilotage cree : `.claude/plans/plan-XX.md`.
-Phase suivante : ecrire les tests — `/pipe-test XX`, dans cette session.
-A tout moment : `/pipe-ship XX` reprend le cycle la ou il en est.
+Plan valide · pilotage `.claude/plans/plan-XX.md`.
+Suite : les tests — `/pipe-test XX` (cette session). `/pipe-ship XX` reprend le cycle a tout moment.
 ```
 
 ---

--- a/skills/pipe-pr/SKILL.md
+++ b/skills/pipe-pr/SKILL.md
@@ -16,13 +16,7 @@ Si une verification echoue, signale-le clairement et arrete-toi.
 
 ### Push
 
-Si la branche n'est pas encore poussee sur le remote, pousse-la :
-
-```
-Push vers origin/[branche-courante]...
-```
-
-Confirme avant de push si c'est le premier push de cette branche.
+Si la branche n'est pas encore poussee sur le remote, pousse-la. Confirme avant de push si c'est le premier push de cette branche. Ne commente pas le push : la sortie de la commande le montre deja.
 
 ## Etape 1 — Recuperer le contexte
 
@@ -70,16 +64,12 @@ Affiche le contenu complet avant de soumettre et demande confirmation.
 **Nouvelle PR :**
 
 ```
----
-Pull Request a creer :
-
-Titre : [Type] Titre de l'issue (#XX)
-Base  : [branche par defaut du projet]
-Head  : type/XX-description
+**PR a creer** — [Type] Titre de l'issue (#XX)
+`type/XX-description` → `[branche par defaut du projet]`
 
 [body complet]
----
-Je cree cette PR sur GitHub ?
+
+Je cree cette PR ?
 ```
 
 **Mise a jour :** affiche la description reecrite + le commentaire d'iteration, puis demande confirmation.
@@ -112,9 +102,8 @@ Propose la suite :
 
 ```
 ---
-PR soumise vers [branche par defaut]. Cycle du ticket termine.
-Quand assez de features sont mergees : `/pipe-release` pour preparer la release
-vers la branche de production, puis `/pipe-tag` apres merge et deploiement.
+PR soumise vers [branche par defaut] — cycle du ticket termine.
+Quand assez de features sont mergees : `/pipe-release`, puis `/pipe-tag` apres deploiement.
 ```
 
 ---

--- a/skills/pipe-release/SKILL.md
+++ b/skills/pipe-release/SKILL.md
@@ -38,9 +38,8 @@ Verifie que le tag `vX.Y.Z` n'existe pas deja (`git tag -l`). Affiche la version
 Liste ce qui part en production :
 
 ```
-## Release vX.Y.Z — [integration] → [production]
+**Release vX.Y.Z** — [integration] → [production]
 
-### PRs incluses
 - #12 [Feat] Titre (PROJ-42)
 - #15 [Fix] Titre (PROJ-45)
 ```

--- a/skills/pipe-review/SKILL.md
+++ b/skills/pipe-review/SKILL.md
@@ -73,9 +73,7 @@ Remplace les crochets par les valeurs reelles avant de lancer le sub-agent.
 **Si le statut est OK** (rien a signaler), affiche une seule ligne — c'est un resultat valide, pas un echec de la review — et ne charge rien de plus :
 
 ```
-## Review — [branche]
-
-Rien a signaler : pas de bug detecte, l'organisation du projet est respectee.
+**Review [branche]** — rien a signaler : pas de bug detecte, organisation du projet respectee.
 ```
 
 **S'il y a des constats** — et seulement dans ce cas — utilise Read pour charger `${CLAUDE_SKILL_DIR}/rendu.md` : format du rapport, motif d'un constat, squelette Question/Reponse de l'etape 5 et exemple complet. Affiche le rapport du sub-agent a ce format.
@@ -88,10 +86,9 @@ C'est la pause du cycle : l'utilisateur relit le code lui-meme, avec le rapport 
 ### A relire
 
 - `chemin/fichier.ts` — [ce que le fichier apporte, une ligne]
-
-Checks : Format ✅ | Lint ✅ | Tests ✅ N passent | Specs ✅
-Rapport : X bloquant(s), Y avertissement(s), Z suggestion(s) — ou "rien a signaler"
 ```
+
+Rien d'autre : les checks et le decompte des constats ont deja ete affiches, les repeter ici n'apprend rien.
 
 Resume chaque fichier depuis le diff. Si l'un ne s'y resume pas, lis-le ponctuellement via Read — celui-la seul, jamais la liste entiere.
 
@@ -161,7 +158,7 @@ Puis coche `Code valide` dans le pilotage.
 
 ```
 ---
-Code valide. Phase suivante : `/pipe-commit [ticket]` pour decouper le travail en commits (meme session).
+Code valide. Suite : `/pipe-commit [ticket]` (meme session).
 ```
 
 ---

--- a/skills/pipe-review/reference.md
+++ b/skills/pipe-review/reference.md
@@ -51,11 +51,11 @@ Pour chaque probleme, produis ces 7 champs structures (utilises ensuite par la p
 
 - **fichier** : chemin et ligne (ex: `src/services/user.service.ts:42`)
 - **severite** : BLOQUANT (bug, faille, regression) / AVERTISSEMENT (dette significative) / SUGGESTION (lisibilite, robustesse)
-- **contexte_fonctionnel** : 1-2 phrases qui resituent le bout de code dans le parcours utilisateur ou le flux metier. Reponds a "qui appelle ce code, dans quelle situation, pour faire quoi ?" en langage du domaine. Pas de noms de fonctions, pas de tags XML/HTML, pas de jargon technique. Si le contexte n'est pas inferrable depuis le diff et les fichiers lus, ecris explicitement "Contexte non identifie depuis le diff" plutot que d'inventer
+- **contexte_fonctionnel** : **une phrase** qui resitue le bout de code dans le parcours utilisateur ou le flux metier. Reponds a "qui appelle ce code, dans quelle situation, pour faire quoi ?" en langage du domaine. Pas de noms de fonctions, pas de tags XML/HTML, pas de jargon technique. Si le contexte n'est pas inferrable depuis le diff et les fichiers lus, ecris explicitement "Contexte non identifie depuis le diff" plutot que d'inventer
 - **probleme_une_phrase** : reformulation **fonctionnelle** du probleme, comprehensible sans le code. **Interdit dans ce champ** : noms de fonctions ou variables, tags XML/HTML, syntaxe de code, noms de types. Exemple : "Si la reponse du logiciel de caisse est incomplete, on continue comme si tout allait bien" et non "La garde `single.children.length > 0` accepte un `<resultCustomerType>` sans `<id>`"
-- **gravite_impact** : la **premiere phrase** doit decrire une consequence concrete et observable cote utilisateur final ou metier (ce qu'il voit, perd, risque). Les nuances de frequence et le contexte technique viennent ensuite. Exemple : "L'utilisateur en caisse verrait un ecran de confirmation avec un numero de carte vide. Cas rare en pratique, mais sans message d'erreur le caissier n'a aucun moyen de comprendre ce qui s'est passe"
+- **gravite_impact** : une consequence concrete et observable cote utilisateur final ou metier (ce qu'il voit, perd, risque), avec sa frequence si elle change la lecture. Une phrase, deux au maximum. Exemple : "L'utilisateur en caisse verrait un ecran de confirmation avec un numero de carte vide, sans message d'erreur pour comprendre pourquoi — rare en pratique"
 - **cause** : explication accessible de l'origine. **Prefere** "le code", "la verification", "la fonction qui parse la reponse" plutot que les noms exacts de symboles. Ne nomme un symbole precis que si c'est indispensable pour pointer le bon endroit
-- **correction** : commence par une **phrase d'introduction fonctionnelle** ("Verifier que la reponse contient bien un numero de carte avant de continuer") puis donne la directive technique courte et actionnable, avec un avant/apres tres bref si pertinent. **Les noms de symboles sont autorises et souvent necessaires ici** pour pointer le fix exact (`saveCache`, `await`, type `Customer`, etc.) — l'interdiction posee sur `probleme_une_phrase` ne s'applique pas a ce champ ni a `cause`
+- **correction** : **une phrase** — l'intention fonctionnelle, puis la directive technique apres deux-points ("Verifier que la reponse contient un numero de carte avant de continuer : garde sur `card.id` avant l'appel a `confirm()`"). **Les noms de symboles sont autorises et souvent necessaires ici** pour pointer le fix exact — l'interdiction posee sur `probleme_une_phrase` ne s'applique ni a ce champ ni a `cause`
 
 **Ce que tu ne fais PAS :**
 - Pas de commentaire sur le style ou le formatting (c'est le role de Biome/ESLint)
@@ -69,6 +69,6 @@ Pour chaque probleme, produis ces 7 champs structures (utilises ensuite par la p
 - `contexte_fonctionnel`, `probleme_une_phrase`, `gravite_impact` s'adressent a quelqu'un qui n'a **pas** le code sous les yeux — un decideur produit, un dev qui reprend le projet la semaine prochaine, ou toi-meme dans 6 mois. Vocabulaire fonctionnel, consequence visible plutot qu'abstraction technique : preferer "ca peut crasher si X est null" a "violation du principe de null-safety".
 - `cause` et `correction` s'adressent au developpeur qui va corriger dans la foulee. Reste precis et actionnable, nomme les symboles quand c'est necessaire.
 
-Une a deux phrases par champ suffisent.
+**Une phrase par champ.** Un champ qui deborde n'est pas plus precis, il est juste plus long a lire.
 
 Produis un rapport structure avec statut global : OK, AVERTISSEMENTS, ou BLOQUANT.

--- a/skills/pipe-review/rendu.md
+++ b/skills/pipe-review/rendu.md
@@ -2,6 +2,8 @@
 
 Ce fichier est charge par le **contexte principal** du skill (jamais par le sub-agent), et seulement quand la review a produit au moins un constat : un statut OK n'a besoin de rien d'ici.
 
+Regle commune aux deux maquettes : **une ligne par idee, aucune phrase de transition**. Ce qui tient sur une ligne ne prend pas un paragraphe ; le detail supplementaire, l'utilisateur le demande s'il le veut.
+
 ## Motif d'un constat
 
 Un constat s'affiche sur trois lignes, quelle que soit sa severite :
@@ -17,11 +19,9 @@ Un constat s'affiche sur trois lignes, quelle que soit sa severite :
 Les trois sections utilisent le meme motif. Ne pas afficher les sections vides.
 
 ```
-## Review — [branche]
+## Review — [branche] · N bloquant(s), M avertissement(s), P suggestion(s)
 
-### Statut : Avertissements / Bloquant
-
-### Problemes bloquants (a corriger avant de continuer)
+### Bloquants
 <constats>
 
 ### Avertissements
@@ -33,25 +33,16 @@ Les trois sections utilisent le meme motif. Ne pas afficher les sections vides.
 
 ## Squelette Question/Reponse (etape 5)
 
-Un probleme a la fois, par severite decroissante, a partir des 7 champs produits par le sub-agent :
+Un probleme a la fois, par severite decroissante, a partir des 7 champs produits par le sub-agent. **Une ligne par champ** — les libelles suffisent, les questions ouvertes sont du remplissage.
 
 ```
-[Severite N/Total] — <fichier>:<ligne>
+**[<Severite> N/Total]** `<fichier>:<ligne>`
+*<contexte_fonctionnel>*
 
-❓ De quoi on parle ?
-   <contexte_fonctionnel>
-
-❓ Le probleme en une phrase
-   <probleme_une_phrase>
-
-❓ C'est grave ?
-   <gravite_impact>
-
-❓ D'ou ca vient ?
-   <cause>
-
-❓ Comment on corrige ?
-   <correction>
+**Probleme** — <probleme_une_phrase>
+**Impact** — <gravite_impact>
+**Cause** — <cause>
+**Fix** — <correction>
 
 → corriger / adapter / ignorer ?
 ```
@@ -59,31 +50,13 @@ Un probleme a la fois, par severite decroissante, a partir des 7 champs produits
 ## Exemple de rendu Question/Reponse
 
 ```
-[Bloquant 1/3] — src/services/user.service.ts:42
+**[Bloquant 1/3]** `src/services/user.service.ts:42`
+*Modification du profil : on met a jour la base, on rafraichit le cache, puis on confirme a l'utilisateur.*
 
-❓ De quoi on parle ?
-   De la modification du profil utilisateur. Quand l'utilisateur
-   enregistre des changements, on met a jour la base, on rafraichit
-   le cache, puis on lui confirme que c'est sauvegarde pour qu'il
-   voie les bonnes infos sur les ecrans suivants.
-
-❓ Le probleme en une phrase
-   On confirme la sauvegarde a l'utilisateur avant que le cache
-   soit reellement a jour.
-
-❓ C'est grave ?
-   L'utilisateur verra l'ancienne version de son profil juste apres
-   l'avoir modifie. Ca se produit environ 1 fois sur 10 selon la
-   charge, et il faut recharger la page pour voir les bonnes infos.
-
-❓ D'ou ca vient ?
-   Le code lance le rafraichissement du cache mais n'attend pas
-   sa fin avant d'envoyer la confirmation. Un mot-cle d'attente
-   est manquant a cet endroit precis.
-
-❓ Comment on corrige ?
-   Attendre la fin du rafraichissement du cache avant de notifier
-   l'utilisateur : ajouter `await` devant l'appel a `saveCache(user)`.
+**Probleme** — on confirme la sauvegarde avant que le cache soit reellement a jour.
+**Impact** — l'utilisateur voit son ancien profil juste apres l'avoir modifie, environ 1 fois sur 10 ; il doit recharger la page.
+**Cause** — le rafraichissement du cache est lance mais pas attendu avant la confirmation.
+**Fix** — attendre le rafraichissement : `await` devant l'appel a `saveCache(user)`.
 
 → corriger / adapter / ignorer ?
 ```

--- a/skills/pipe-ship/SKILL.md
+++ b/skills/pipe-ship/SKILL.md
@@ -37,8 +37,7 @@ Le dev et la review se font chacun dans une session neuve, avec un contexte prop
 - Si la phase a executer exige une session neuve **et** qu'une autre phase vient d'etre executee dans cette conversation, ne pas enchainer. Afficher :
 
 ```
-Phase suivante : [dev | review] — a lancer dans une NOUVELLE session :
-ouvre une session et lance `/pipe-ship [ticket]`.
+Suite : [dev | review], dans une **nouvelle session** — `/pipe-ship [ticket]`.
 ```
 
 - Si `/pipe-ship` est lance en debut de session (rien d'autre execute avant), executer la phase courante directement, quelle qu'elle soit.

--- a/skills/pipe-spec/SKILL.md
+++ b/skills/pipe-spec/SKILL.md
@@ -135,18 +135,15 @@ Une fois l'accord obtenu, et **seulement alors**, mets le pilotage a jour (s'il 
 
 ```
 ---
-Spec [creee | mise a jour] : `docs/specs/<feature>.md`.
-Pilotage : `.claude/plans/plan-<identifiant>.md`.
-Phase suivante : planifier le dev — `/pipe-plan <ticket>`, dans cette session.
-A tout moment : `/pipe-ship <ticket>` reprend le cycle la ou il en est.
+Spec [creee | mise a jour] `docs/specs/<feature>.md` · pilotage `.claude/plans/plan-<identifiant>.md`.
+Suite : le plan — `/pipe-plan <ticket>` (cette session). `/pipe-ship <ticket>` reprend le cycle a tout moment.
 ```
 
 **Usage autonome (sans ticket)** :
 
 ```
 ---
-Spec [creee | mise a jour] : `docs/specs/<feature>.md`.
-Elle sera committee avec le prochain changeset (`/pipe-commit`).
+Spec [creee | mise a jour] `docs/specs/<feature>.md` — sera committee avec le prochain changeset (`/pipe-commit`).
 ```
 
 **En mode inventaire**, ajoute le reste a faire — c'est ce qui permet de reprendre le rattrapage plus tard :

--- a/skills/pipe-tag/SKILL.md
+++ b/skills/pipe-tag/SKILL.md
@@ -54,8 +54,7 @@ Ne charger `${CLAUDE_SKILL_DIR}/reference.md` que si le cas sort de ce cadre —
 Afficher :
 
 ```
-Version cible : vX.Y.Z
-Dernier tag existant : [tag ou "aucun"]
+Version cible **vX.Y.Z** · dernier tag [tag ou "aucun"]
 ```
 
 Verifier que le tag `vX.Y.Z` n'existe pas deja (`git tag -l "vX.Y.Z"`). Si le tag existe deja, signaler l'erreur et s'arreter.
@@ -77,17 +76,11 @@ sed -n '/^## \[1\.2\.3\]/,/^## \[/{/^## \[/d;/^\[[^]]*\]: /d;p;}' CHANGELOG.md
 Afficher le recapitulatif :
 
 ```
----
-Tag a creer :
+**Tag vX.Y.Z** — annote, message `Release vX.Y.Z`
 
-  Version : vX.Y.Z
-  Type    : annote
-  Message : Release vX.Y.Z
+[notes extraites du CHANGELOG, ou "(aucune note)" si section absente]
 
-  Notes :
-  [contenu extrait du CHANGELOG ou "(aucune note)" si section absente]
----
-Je cree et pousse le tag vX.Y.Z ?
+Je cree et pousse ce tag ?
 ```
 
 Attendre la confirmation explicite avant de continuer.
@@ -110,17 +103,12 @@ Attendre la confirmation explicite avant de continuer.
    git push origin vX.Y.Z
    ```
 
-Afficher la confirmation :
-
-```
-Tag vX.Y.Z cree et pousse sur origin.
-```
-
 ## Etape 5 — Proposer la suite
 
+Une seule ligne pour la confirmation et la suite — les annoncer separement, c'est dire deux fois la meme chose :
+
 ```
----
-Tag vX.Y.Z publie. Pipeline termine.
+Tag vX.Y.Z cree et pousse sur origin. Pipeline termine.
 ```
 
 ---

--- a/skills/pipe-test/SKILL.md
+++ b/skills/pipe-test/SKILL.md
@@ -82,8 +82,7 @@ Le dev se fait dans une session neuve, avec un contexte propre — le pilotage e
 
 ```
 ---
-Tests valides. Phase suivante : le dev, dans une NOUVELLE session :
-ouvre une session et lance `/pipe-ship [ticket]` (ou `/pipe-code [ticket]`).
+Tests valides. Suite : le dev, dans une **nouvelle session** — `/pipe-ship [ticket]`.
 ```
 
 ---


### PR DESCRIPTION
Version cible : **1.6.2**

## CHANGELOG

### Changed

- Les skills du pipeline affichent des sorties compactes : une ligne de statut plutôt qu'un titre suivi d'une métrique, un fait par ligne, et plus de récapitulatif répété d'une étape à l'autre. Le rapport de review passe de 22 à 8 lignes par constat, sans rien perdre de son contenu ([`19bc699`](https://github.com/alex-robert-fr/claude-workflow/commit/19bc699))

## Contenu

Aucune PR incluse — deux commits directs sur `develop` :

- `19bc699` ♻️ refactor(skills): compacter les rendus du pipeline
- `321b7b2` 🔧 chore(release): preparer la version 1.6.2

`plugin.json` passe à 1.6.2 : sans ce bump, `/plugin update` répond « already at the latest version » et personne ne reçoit le changement.
