### PR TITLE
[Release] v1.6.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "description": "Pipeline AI-Driven Development : setup, plan, code, review, test, changelog, PR, tag",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "author": {
     "name": "ToolsForSaaS"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-07-31
+
+### Changed
+
+- Le dépôt du plugin a déménagé vers `alex-robert-fr/claude-workflow` : c'est désormais cette adresse qu'il faut utiliser pour `/plugin marketplace add`. Les installations existantes continuent de fonctionner par redirection GitHub ([`954556b`](https://github.com/alex-robert-fr/claude-workflow/commit/954556b))
+
 ## [1.6.2] - 2026-07-30
 
 ### Changed
@@ -263,7 +269,8 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.2...HEAD
+[Unreleased]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.3...HEAD
+[1.6.3]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.5.0...v1.6.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lecture de tickets compatible **GitHub** et **Jira** (hierarchie epic → versio
 Dans Claude Code :
 
 ```
-/plugin marketplace add ToolsForSaaS/claude-workflow
+/plugin marketplace add alex-robert-fr/claude-workflow
 /plugin install claude-workflow
 ```
 
@@ -32,7 +32,7 @@ Puis recharger les plugins :
 ### Via clone local (dev / contribution)
 
 ```bash
-git clone git@github.com:ToolsForSaaS/claude-workflow.git
+git clone git@github.com:alex-robert-fr/claude-workflow.git
 ```
 
 Puis dans `.claude/settings.json` du projet cible :
@@ -221,5 +221,5 @@ Ces fichiers ne sont jamais ecrases par une mise a jour du plugin.
 ## Ressources
 
 - [CHANGELOG.md](CHANGELOG.md) — historique des versions et evolutions du plugin
-- [Repository GitHub](https://github.com/ToolsForSaaS/claude-workflow)
+- [Repository GitHub](https://github.com/alex-robert-fr/claude-workflow)
 - [Conventions du plugin](CLAUDE.md) — regles internes pour contribuer

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -30,4 +30,5 @@ Ecrites et maintenues par `/pipe-spec`, verifiees a chaque `/pipe-review`.
 | Configuration d'un projet | [`configuration-d-un-projet.md`](configuration-d-un-projet.md) | Diagnostique ce qui manque au projet, puis n'installe que ce qui manque |
 | Creation d'issues | [`creation-d-issues.md`](creation-d-issues.md) | Transforme une demande libre en issues decoupees et acceptables |
 | Garde-fous outilles | [`garde-fous-outilles.md`](garde-fous-outilles.md) | Des scripts deployes par /setup qui font respecter les regles sans le LLM |
+| Sorties vers l'humain | [`sorties-vers-l-humain.md`](sorties-vers-l-humain.md) | Telegraphique pour les faits, developpe des qu'une decision est attendue |
 | Worktrees paralleles | [`worktrees-paralleles.md`](worktrees-paralleles.md) | Plusieurs branches cote a cote, sans remiser le travail en cours |

--- a/docs/specs/sorties-vers-l-humain.md
+++ b/docs/specs/sorties-vers-l-humain.md
@@ -48,9 +48,9 @@ Les maquettes de rendu reellement variables — celles qu'un skill n'affiche que
 
 | Version | Ticket | Decision | Raison | Alternative ecartee |
 |---------|--------|----------|--------|---------------------|
-| 1.7.0 (a venir) | — | Deux regimes : constat dense, sollicitation developpee | Une densite uniforme a produit des questions cryptiques : options telegraphiques, jargon non defini, consequences absentes | Garder la densite prioritaire partout et ne corriger que les abus — le fond serait revenu |
-| 1.7.0 (a venir) | — | Les options d'une sollicitation se formulent en comportement | Un libelle qui nomme un fichier oblige a connaitre le code pour repondre, ce qui deplace la charge sur l'humain | Nommer la couche ou le module concerne |
-| 1.7.0 (a venir) | — | La spec ne prescrit aucun moyen de mise en oeuvre | Frontiere spec/plan : un outil ou un script d'apprentissage se choisit au plan et peut changer sans que la regle bouge | Engager des le cadrage un garde-fou outille |
+| 1.6.3 | — | Deux regimes : constat dense, sollicitation developpee | Une densite uniforme a produit des questions cryptiques : options telegraphiques, jargon non defini, consequences absentes | Garder la densite prioritaire partout et ne corriger que les abus — le fond serait revenu |
+| 1.6.3 | — | Les options d'une sollicitation se formulent en comportement | Un libelle qui nomme un fichier oblige a connaitre le code pour repondre, ce qui deplace la charge sur l'humain | Nommer la couche ou le module concerne |
+| 1.6.3 | — | La spec ne prescrit aucun moyen de mise en oeuvre | Frontiere spec/plan : un outil ou un script d'apprentissage se choisit au plan et peut changer sans que la regle bouge | Engager des le cadrage un garde-fou outille |
 
 ## Points d'entree
 

--- a/docs/specs/sorties-vers-l-humain.md
+++ b/docs/specs/sorties-vers-l-humain.md
@@ -1,0 +1,60 @@
+# Sorties vers l'humain
+
+> **Statut** : active
+> **Tickets** : —
+
+## En une phrase
+
+Tout ce qu'un skill affiche — recap, rapport, question — obeit a une grammaire commune : telegraphique pour les faits acquis, developpe des qu'une decision est attendue.
+
+## Intention
+
+Une sortie de skill est une interface, relue a chaque invocation : la densite y a une vraie valeur. Mais compressee au-dela du point d'intelligibilite, elle coute plus cher qu'elle ne rapporte — l'utilisateur relit, redemande, ou tranche a l'aveugle. On reconnait une sortie reussie a ce qu'elle permet d'agir sans rouvrir le code ni demander de precision.
+
+## Philosophie
+
+On parle metier, pas fichiers : un chemin ou un nom de symbole illustre, il ne remplace jamais l'enonce du comportement en jeu. L'arbitrage densite/intelligibilite ne se rejoue pas a chaque sortie — c'est le type de sortie qui tranche.
+
+## Comportement attendu
+
+- Deux regimes, et le critere est unique : une sortie qui **constate** est telegraphique, une sortie qui **sollicite une decision** porte le contexte necessaire pour trancher
+- Un constat tient un fait par ligne, libelle en gras puis tiret cadratin, tableau des trois colonnes de faits
+- Une sollicitation enonce **une seule** decision : deux decisions cousues par un « et » font deux sollicitations
+- Chaque option d'une sollicitation nomme le choix par le comportement qu'il produit, jamais par le fichier ou la couche qui l'heberge
+- Chaque option enonce sa consequence — ce qui change concretement si on la retient
+- Tout terme technique introduit par une sollicitation est defini a son premier usage, ou remplace par un terme metier
+- Un extrait de code ou une arborescence **illustre** une sollicitation sans la porter : retire, la question reste comprehensible
+- Aucune sortie ne reaffiche ce que l'utilisateur a deja sous les yeux — sortie de commande, fichier montre, recap d'une etape precedente
+- Aucune phrase d'introduction ni de transition, dans les deux regimes
+- Une fin d'etape tient sur une ligne : le geste suivant et la commande
+
+## Hors scope
+
+- Le style conversationnel hors sortie de skill — la grammaire couvre ce que les skills affichent, pas la longueur des reponses en general
+- Le contenu des artefacts produits (spec, plan, commits, PR) — chacun porte son propre budget dans son skill
+- Les moyens de mise en oeuvre : outil de choix multiple, gabarits imposes, script de verification relevent du plan, pas du cadrage
+
+## Fonctionnement technique
+
+La grammaire ne s'applique pas a l'execution mais a **l'ecriture des skills** : elle vit dans la doctrine locale du repo, et chaque skill en herite au moment ou il decrit ce qu'il affiche. Elle n'est donc pas distribuee dans le plugin — la faire porter par le prompt de chaque session reviendrait a payer une regle de conception a chaque invocation.
+
+Les maquettes de rendu reellement variables — celles qu'un skill n'affiche que dans certains cas — vivent dans un fichier charge a la demande plutot que dans le corps du skill.
+
+## Dependances
+
+- **Dependants** : [`review-de-fin-de-cycle.md`](review-de-fin-de-cycle.md) et [`plan-technique-d-un-ticket.md`](plan-technique-d-un-ticket.md), dont les pauses humaines sont des sollicitations
+
+## Decisions
+
+| Version | Ticket | Decision | Raison | Alternative ecartee |
+|---------|--------|----------|--------|---------------------|
+| 1.7.0 (a venir) | — | Deux regimes : constat dense, sollicitation developpee | Une densite uniforme a produit des questions cryptiques : options telegraphiques, jargon non defini, consequences absentes | Garder la densite prioritaire partout et ne corriger que les abus — le fond serait revenu |
+| 1.7.0 (a venir) | — | Les options d'une sollicitation se formulent en comportement | Un libelle qui nomme un fichier oblige a connaitre le code pour repondre, ce qui deplace la charge sur l'humain | Nommer la couche ou le module concerne |
+| 1.7.0 (a venir) | — | La spec ne prescrit aucun moyen de mise en oeuvre | Frontiere spec/plan : un outil ou un script d'apprentissage se choisit au plan et peut changer sans que la regle bouge | Engager des le cadrage un garde-fou outille |
+
+## Points d'entree
+
+| Fichier | Role |
+|---------|------|
+| `.claude/skills/create-skill/guide.md` | Section « Grammaire de sortie » : la regle, appliquee a l'ecriture de chaque skill |
+| `skills/pipe-review/rendu.md` | Maquettes de constat et de sollicitation de la review |


### PR DESCRIPTION
Version cible : **1.6.3**

## CHANGELOG

### Changed

- Le dépôt du plugin a déménagé vers `alex-robert-fr/claude-workflow` : c'est désormais cette adresse qu'il faut utiliser pour `/plugin marketplace add`. Les installations existantes continuent de fonctionner par redirection GitHub

## Commits inclus

Aucune PR de feature dans cette release — les trois commits ont été poussés directement sur `develop`.

- `954556b` 📝 docs: pointer le README sur la nouvelle adresse du depot
- `d92de4f` 📝 docs(specs): cadrer les sorties du pipeline vers l'humain
- `f508448` 🔧 chore(release): preparer la version 1.6.3

La spec `docs/specs/sorties-vers-l-humain.md` n'apparaît pas au CHANGELOG : c'est de la documentation interne au repo, sans effet pour qui consomme le plugin. Ses trois décisions de journal sont figées en 1.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)