### PR TITLE
[Release] v1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "toolsforsaas-workflow",
   "owner": {
     "name": "ToolsForSaaS"
@@ -12,14 +12,14 @@
       "name": "claude-workflow",
       "source": {
         "source": "github",
-        "repo": "ToolsForSaaS/claude-workflow"
+        "repo": "alex-robert-fr/claude-workflow"
       },
       "description": "Plugin Claude Code pour le workflow AI-Driven Development. Fournit un pipeline complet : setup, plan, code, review, test, changelog, PR, tag.",
       "author": {
         "name": "ToolsForSaaS"
       },
-      "homepage": "https://github.com/ToolsForSaaS/claude-workflow",
-      "repository": "https://github.com/ToolsForSaaS/claude-workflow",
+      "homepage": "https://github.com/alex-robert-fr/claude-workflow",
+      "repository": "https://github.com/alex-robert-fr/claude-workflow",
       "license": "MIT",
       "keywords": [
         "workflow",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "description": "Pipeline AI-Driven Development : setup, plan, code, review, test, changelog, PR, tag",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "author": {
     "name": "ToolsForSaaS"
   }

--- a/.claude/scripts/check-skills.sh
+++ b/.claude/scripts/check-skills.sh
@@ -7,15 +7,26 @@
 # Detecte les ecarts a la doctrine maison qu'aucune relecture ne rattrape :
 #   - une description trop longue : elle est injectee dans le prompt systeme de
 #     CHAQUE session, c'est un cout permanent
-#   - une DIRECTIVE DE CHARGEMENT citant un fichier support sans chemin qualifie :
-#     Read exige un chemin absolu, un nom nu n'est resolvable que depuis le cwd de
-#     ce repo, pas depuis un plugin installe
+#   - une DIRECTIVE DE CHARGEMENT citant un fichier support OU un autre skill sans
+#     chemin qualifie : Read exige un chemin absolu, un nom nu n'est resolvable que
+#     depuis le cwd de ce repo, pas depuis un plugin installe
 #   - un skill invocable sans $ARGUMENTS : l'argument utilisateur est perdu
 #   - un corps trop long sans fichier support : le seuil de delegation n'est pas tenu
 #   - le diagramme du pipeline divergent entre ses trois copies
 
 ROOT="${CLAUDE_PROJECT_DIR:-.}"
 status=0
+
+# Noms des skills distribues, pour le check 2. Sans cette liste, la detection ne
+# porterait que sur les fichiers annexes (reference.md, guide.md) et laisserait
+# passer un chargement par nom de skill nu — l'ecart le plus silencieux, puisqu'il
+# echoue seulement une fois le plugin installe ailleurs.
+skill_names=""
+for d in "$ROOT"/skills/*/; do
+  [ -d "$d" ] || continue
+  skill_names="$skill_names|$(basename "$d")"
+done
+skill_names="${skill_names#|}"
 
 for skill in "$ROOT"/skills/*/SKILL.md "$ROOT"/.claude/skills/*/SKILL.md; do
   [ -f "$skill" ] || continue
@@ -35,11 +46,21 @@ for skill in "$ROOT"/skills/*/SKILL.md "$ROOT"/.claude/skills/*/SKILL.md; do
   # produit aucun Read : la signaler serait du bruit, et le bruit fait ignorer
   # le check. On exige ensuite un chemin sur la ligne : ${CLAUDE_SKILL_DIR}/,
   # skills/... ou .claude/...
+  #
+  # Deux formes de nom nu sont cherchees : un fichier support (reference.md,
+  # guide.md) et un AUTRE skill cite en backticks (`git-conventions`). Le nom du
+  # skill courant est exclu — il se cite lui-meme sans rien charger. Les backticks
+  # sont exiges colles au nom, ce qui laisse passer `/pipe-commit` : une invocation
+  # de commande n'est pas un chargement de fichier.
+  others=$(printf '%s' "$skill_names" | tr '|' '\n' | grep -vx "$name" | paste -sd'|' -)
+  motif='(reference|guide)\.md'
+  [ -n "$others" ] && motif="$motif|\`($others)\`"
+
   while IFS=: read -r ln text; do
     [ -z "$ln" ] && continue
     echo "SKILL $name — chargement a chemin nu ligne $ln : $(printf '%s' "$text" | sed 's/^[ \t*-]*//' | cut -c1-60)"
     status=1
-  done < <(grep -nE '(reference|guide)\.md' "$skill" \
+  done < <(grep -nE "$motif" "$skill" \
     | grep -E 'Read|charge|charger' \
     | grep -vE '\$\{CLAUDE_SKILL_DIR\}|(^|[^a-z])(skills|\.claude)/')
 

--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -13,7 +13,7 @@ argument-hint: [description du skill a creer]
 ### Conventions de ce repo
 
 - Nommage : `kebab-case`, chaque skill est un repertoire `nom/SKILL.md`
-- Prefixes : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `*-conventions` (expertise)
+- Prefixes : `pipe-*` (pipeline), `create-*` (artefacts), `audit-*` (conformite), `setup-*` (config), `*-conventions` (expertise)
 - Skills invocables : `user-invocable: true` (defaut). Skills expertise : `user-invocable: false`
 - `$ARGUMENTS` toujours en fin de skill invocable
 - Pas de champ `model` dans le frontmatter : il bascule reellement le modele pour le reste du tour (auto-invocation comprise) et peut retrograder la session. Voir `reference.md` section `model`

--- a/.claude/skills/workflow-config/SKILL.md
+++ b/.claude/skills/workflow-config/SKILL.md
@@ -11,7 +11,7 @@ disable-model-invocation: true
 
 ## Plateforme
 
-- **Git hosting** : GitHub (`OnVaEtreMillionnaire/claude-workflow`)
+- **Git hosting** : GitHub (`alex-robert-fr/claude-workflow`)
 - **Issue tracker** : GitHub Issues
 - **Branche par defaut** : `develop` — base des features et cible de leurs PRs
 - **Branche de production** : `main` — cible des PRs de release

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Restent ignores par la regle ci-dessus, listes ici pour l'intention :
 #   .claude/settings.local.json  — permissions propres a la machine
 #   .claude/plans/               — fichiers de pilotage, ephemeres, supprimes a la PR
+#   .claude/audits/              — rapports d'audit de conformite, ephemeres
 #   .claude/hooks/               — copies produites par /setup depuis skills/setup/scripts/
 
 # Ne jamais utiliser de motif nu comme `settings.json` : non ancre, il ignorerait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-01
+
+### Added
+
+- Nouveau skill `/audit-conformity` : auditer la conformité du code à un document de référence (spec, règle, skill, `CLAUDE.md`) et planifier la remédiation ([#59](https://github.com/alex-robert-fr/claude-workflow/pull/59))
+
+### Fixed
+
+- Le marketplace pointe désormais sur le dépôt réellement publié : `/plugin install` et `/plugin update` installent bien ce plugin ([#59](https://github.com/alex-robert-fr/claude-workflow/pull/59))
+- `/pipe-code` charge à nouveau les conventions git depuis un plugin installé, et non plus seulement depuis le dépôt source ([#59](https://github.com/alex-robert-fr/claude-workflow/pull/59))
+
 ## [1.6.3] - 2026-07-31
 
 ### Changed
@@ -269,7 +280,8 @@ Les détails techniques de chaque changement sont documentés dans les commits e
 - Préfixage des skills par catégorie : `pipe-*` (pipeline), `create-*` (artefacts), `setup-*` (config), `audit-*` (audits) ([#8](https://github.com/ToolsForSaaS/claude-workflow/pull/8))
 - Installation du plugin via la marketplace Claude Code ([`951edeb`](https://github.com/ToolsForSaaS/claude-workflow/commit/951edeb))
 
-[Unreleased]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.3...HEAD
+[Unreleased]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.3...v1.7.0
 [1.6.3]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/alex-robert-fr/claude-workflow/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/ToolsForSaaS/claude-workflow/compare/v1.6.0...v1.6.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Deux documents, deux durees de vie — ne jamais les confondre. La **spec** (`do
 
 - Les fichiers de `skills/` sont **partages** — distribues via le plugin. `.claude/` porte l'outillage local du repo (create-skill, scripts de check) et n'est jamais distribue
 - Les templates projet-specifiques sont dans `skills/setup/`, deployes par `/setup`. `workflow-config` est la source unique de config projet (plateforme, commandes, stack)
-- **Un script est un fichier, jamais un bloc de code dans un markdown.** Les scripts sans variable projet vivent dans `skills/setup/scripts/*.sh` et sont **copies** par `/setup` (`cp` + `chmod +x`). Faire recopier un script par le LLM depuis un markdown, c'est lui confier un travail deterministe — avec le risque d'erreur d'echappement en prime. Les markdown ne gardent que les templates reellement variables (commandes de lint, format, test) et l'explication des scripts, pas leur code
+- **Un script est un fichier, jamais un bloc de code dans un markdown** : les scripts sans variable projet vivent dans `skills/setup/scripts/*.sh` et sont **copies** par `/setup`. Seuls les templates reellement variables (commandes de lint, format, test) restent dans les markdown — le pourquoi est dans `README.md`
 - La qualite est garantie par les **hooks** et les **sub-agents**, jamais par des instructions au LLM. Les garde-fous outilles : `.claude/scripts/check-skills.sh` (budget et coherence des skills), `skills/setup/scripts/check-specs.sh` (coherence des specs, lance par `/pipe-review`)
 - Ne jamais mettre de logique specifique a un projet dans les skills partages
 - Chaque skill est un repertoire `nom/SKILL.md` avec frontmatter obligatoire
@@ -35,4 +35,4 @@ Deux documents, deux durees de vie — ne jamais les confondre. La **spec** (`do
 
 - Ecrire ou modifier un skill : `.claude/skills/create-skill/` (conventions de nommage, frontmatter, seuils de delegation)
 - Commits, branches, Pull Requests : `skills/git-conventions/SKILL.md` — a respecter systematiquement
-- Publier une version : `/pipe-release` puis `/pipe-tag`. La version de `plugin.json` est la **cle de cache des mises a jour** : sans bump, aucun utilisateur ne recoit quoi que ce soit et `/plugin update` repond « already at the latest version ». Panne totale et silencieuse, qu'aucun test ne rattrape — lancer `.claude/scripts/bump-version.sh X.Y.Z`, jamais editer a la main
+- Publier une version : `/pipe-release` puis `/pipe-tag`. La version de `plugin.json` est la **cle de cache des mises a jour** : sans bump, aucun utilisateur ne recoit quoi que ce soit et `/plugin update` repond « already at the latest version ». Panne totale et silencieuse, qu'aucun test ne rattrape — lancer `.claude/scripts/bump-version.sh X.Y.Z`, jamais editer a la main. Meme exigence pour la cible d'installation de `marketplace.json` (`repo`, `homepage`, `repository`) : divergente du remote, elle fait installer un autre depot que celui publie

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Configurer un workflow AI-Driven Development de zero, c'est des dizaines d'heure
 
 **Pour qui ?** Les devs solo et les equipes qui veulent un workflow Claude Code structure sans tout reinventer. **Quel benefice ?** Une reduction de la charge mentale (un seul geste a retenir : `/pipe-ship <ticket>` reprend le cycle ou il en est), l'humain qui n'intervient qu'aux vrais points de decision (le plan, les tests, le code), une qualite garantie par les vrais outils et les hooks (pas par des instructions au LLM), et une coherence entre les sessions et les projets menes en parallele.
 
-**15 skills** distribues : chaque etape du cycle est un skill invocable independamment, et `/pipe-ship` les enchaine depuis le fichier de pilotage.
+**16 skills** distribues : chaque etape du cycle est un skill invocable independamment, et `/pipe-ship` les enchaine depuis le fichier de pilotage.
 
 Lecture de tickets compatible **GitHub** et **Jira** (hierarchie epic → version → demande) — la creation d'issues et de Pull Requests reste sur **GitHub** uniquement.
 
@@ -166,6 +166,7 @@ Commandes invocables a tout moment, hors du flow principal du pipeline.
 | [`setup`](skills/setup/SKILL.md) | Configuration complete du projet, one-shot (slash-only) |
 | [`create-issue`](skills/create-issue/SKILL.md) | Issues GitHub structurees avec decoupage |
 | [`worktree`](skills/worktree/SKILL.md) | Creer, lister, supprimer et basculer entre worktrees git |
+| [`audit-conformity`](skills/audit-conformity/SKILL.md) | Auditer le code contre un document de reference (spec, regle, skill) et planifier la remediation |
 
 ### Referentiels (consultables, non-invocables)
 
@@ -189,7 +190,7 @@ claude-workflow/
 ├── CLAUDE.md                # conventions du plugin
 ├── CHANGELOG.md             # historique des versions
 └── skills/
-    ├── <nom>/               # 15 skills, un repertoire par skill
+    ├── <nom>/               # 16 skills, un repertoire par skill
     │   ├── SKILL.md         # point d'entree (frontmatter + flow)
     │   └── reference.md     # referentiel detaille (optionnel)
     └── setup/scripts/       # scripts universels, copies tels quels par /setup

--- a/docs/specs/changelog-et-release.md
+++ b/docs/specs/changelog-et-release.md
@@ -70,4 +70,4 @@ La version du plugin se resout par ordre de priorite : le champ de `plugin.json`
 - **Ne pas bumper la version est une panne totale et silencieuse.** Elle sert de cle de cache : pousser des commits ne suffit pas, la mise a jour repond que tout est deja a jour et personne ne recoit rien. Aucun test, aucun lint et aucune review ne rattrapent cet oubli
 - **Aucun skill ne declenche le bump** : la chaine de release l'ignore, il reste a lancer a la main
 - **Ni l'entree marketplace ni le champ de compatibilite ascendante ne doivent revenir** : ils ne cassent rien, ils mentent — une version affichee qui n'est jamais celle qui s'applique
-- **La cible d'installation declaree dans le marketplace differe du remote de ce repo**, et le schema qu'il declare est introuvable. A verifier avant la prochaine publication
+- **La cible d'installation du marketplace doit suivre le remote** : `repo`, `homepage` et `repository` pointent vers le depot reel, sinon l'installation vise un autre depot que celui publie

--- a/skills/audit-conformity/SKILL.md
+++ b/skills/audit-conformity/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: audit-conformity
+description: Auditer la conformite du code a un document de reference (spec, regle, skill, CLAUDE.md) et planifier la remediation.
+argument-hint: [document de reference] [perimetre optionnel]
+---
+
+Ce skill repond a une seule question : **ce que ce document affirme est-il vrai partout dans le code ?** Le document est la loi, le code est le prevenu — jamais l'inverse. Un ecart se tranche a la fin, pas pendant l'audit.
+
+Il ne modifie aucune ligne de code. Il produit un rapport de conformite, un plan de remediation en lots, et propose leur mise en place dans le pipeline.
+
+## Etape 0 — Verifications
+
+- [ ] Un document de reference est identifie et lisible
+- [ ] Utilise Read pour charger `.claude/skills/workflow-config/SKILL.md` s'il existe (stack et conventions du projet : ils cadrent le perimetre)
+
+Sans argument, ou si le document est ambigu, inventorie les candidats (`docs/specs/*.md`, `CLAUDE.md`, `.claude/skills/*/SKILL.md`, `skills/*/SKILL.md`) et demande lequel auditer. **N'en audite jamais plusieurs a la fois** : les grilles se melangeraient et le rapport deviendrait illisible.
+
+Le second argument, optionnel, restreint le perimetre (`src/auth/`, `**/*.tsx`). Sans lui, le perimetre est le projet entier.
+
+## Etape 1 — Extraire la grille de regles (pause)
+
+C'est l'etape qui decide de la valeur de tout le reste : des auditeurs lances sur une interpretation fausse produisent un rapport faux, avec conviction.
+
+Lis le document en entier, puis convertis-le en **regles atomiques numerotees** `R1..Rn`. Le critere d'atomicite : un auditeur doit pouvoir repondre **oui ou non** en regardant un fichier, sans rien interpreter. Les criteres de decoupage, le format de la grille et le tri normatif/non-verifiable sont dans `${CLAUDE_SKILL_DIR}/reference.md`, section « Extraction de la grille ».
+
+Affiche la grille et **attends validation**. L'utilisateur corrige ici les regles mal lues, retire celles qui ne s'appliquent plus, ajoute l'implicite que le document ne dit pas. Sans cette pause, l'audit est une opinion.
+
+## Etape 2 — Cartographier le perimetre
+
+Etablis la liste des fichiers concernes (Glob), exclusions comprises : dependances, artefacts de build, fichiers generes, lockfiles, `.git`.
+
+Decoupe-la en **zones equilibrees** par repertoire ou module — jamais par regle : un auditeur qui ne connait qu'une regle rate les interactions entre elles, et relit le meme fichier n fois.
+
+| Fichiers dans le perimetre | Zones (auditeurs) |
+|---|---|
+| < 30 | 2 |
+| 30 – 150 | 3 a 4 |
+| > 150 | 5 a 6 |
+
+Au-dela de 6 zones, elargis chaque zone plutot que le nombre d'agents : la synthese devient le goulot.
+
+Annonce en une ligne : `Perimetre — N fichiers · G zones · R regles`.
+
+## Etape 3 — Auditer (fan-out)
+
+Lance **un sub-agent par zone**, tous dans **un seul message** pour qu'ils tournent en parallele. Outil Agent, type `Explore` (read-only : un auditeur ne corrige rien).
+
+Chaque agent recoit la **grille entiere** et **sa zone seule**. Le protocole de l'auditeur — obligation de preuve `fichier:ligne`, verdict par regle, interdiction de signaler du gout — est dans `${CLAUDE_SKILL_DIR}/reference.md`, section « Protocole de l'auditeur » : il s'adresse aux sub-agents, ne le charge jamais dans le contexte principal.
+
+```
+Utilise Read pour charger `[chemin absolu de ${CLAUDE_SKILL_DIR}/reference.md]` et applique la section "Protocole de l'auditeur".
+
+Document de reference : [chemin]
+Ta zone : [liste des fichiers ou glob]
+Grille a verifier :
+[grille R1..Rn validee a l'etape 1]
+```
+
+## Etape 4 — Refuter (contre-audit)
+
+Une violation non refutee est une violation supposee. Regroupe les constats par regle, et lance **un refutateur par lot** (Agent, `Explore`, en parallele) — pas un par violation, le cout exploserait sans gain.
+
+Sa consigne : **detruire** le constat, pas le confirmer. Quatre sorties possibles — faux positif, exception legitime, regle mal interpretee, **la regle elle-meme est mauvaise**. En cas de doute, le defaut est `refute`. Protocole complet dans `${CLAUDE_SKILL_DIR}/reference.md`, section « Protocole du refutateur ».
+
+Les constats refutes ne disparaissent pas : ils vont dans une section a part du rapport, avec le motif. C'est ce qui evite de les redecouvrir au prochain audit.
+
+## Etape 5 — Chasser les angles morts
+
+Un audit se juge autant sur ce qu'il n'a pas vu. Lance **un seul** sub-agent critique (Agent, `Explore`), avec la grille, la carte des zones et les rapports agreges. Sa question : quelle regle n'a jamais ete reellement evaluee, quelle zone n'a ete que survolee, quel faux negatif est probable ? Protocole dans `${CLAUDE_SKILL_DIR}/reference.md`, section « Protocole du critique ».
+
+S'il remonte des trous, lance **une** salve ciblee d'auditeurs dessus, puis passe a la suite. Une seule relance : au-dela, c'est la grille qu'il faut revoir, pas le nombre d'agents.
+
+## Etape 6 — Rapport de conformite
+
+Ecris `.claude/audits/audit-<slug>.md` (cree le repertoire si besoin, verifie qu'il est dans `.gitignore` — un rapport d'audit est ephemere, il n'a pas a etre versionne).
+
+Le format du rapport est dans `${CLAUDE_SKILL_DIR}/reference.md`, section « Format du rapport ». A l'ecran, n'affiche que la synthese dense : le tableau des regles avec leur verdict, et le decompte des violations confirmees par severite. Le detail est dans le fichier, l'utilisateur l'ouvre s'il le veut.
+
+Conformite totale est un **resultat valide** : le dire en une ligne, ecrire le rapport, et s'arreter la.
+
+## Etape 7 — Arbitrage humain (pause)
+
+Parcours les violations confirmees, par severite. Pour chacune, trois issues — et la troisieme compte autant que les autres :
+
+- **Corriger le code** — l'ecart part au plan de remediation
+- **Amender le document** — c'est la regle qui est fausse, obsolete ou trop large ; la correction va dans le document de reference, pas dans le code
+- **Accepter l'ecart** — avec sa raison, consignee dans le rapport ; sans raison ecrite, il reviendra a chaque audit
+
+Ne corrige rien ici, meme trivial : ce skill audite, il n'edite pas. Attends une decision explicite par violation.
+
+## Etape 8 — Plan de remediation et mise en place
+
+Regroupe les ecarts a corriger en **lots coherents** — par zone du code ou par regle, selon ce qui produit le moins de conflits entre eux — ordonnes par severite puis par dependance. Format dans `${CLAUDE_SKILL_DIR}/reference.md`, section « Plan de remediation ».
+
+Chaque lot recoit une route, selon la regle de tri du projet (comportement a valider → cycle ; rien a tester → voie rapide) :
+
+| Nature du lot | Route |
+|---|---|
+| Mecanique, aucun comportement touche | `/pipe-commit` (voie rapide) |
+| Comportement a valider, feature existante | `/pipe-spec` puis le cycle |
+| Chantier a suivre dans le tracker | `/create-issue` |
+
+Puis propose la mise en place et **attends confirmation** :
+
+```
+Plan — N lots · [x] voie rapide, [y] cycle, [z] issues.
+Je mets en place le lot 1 ([route]) ?
+```
+
+Enchaine lot par lot, jamais tous d'un coup : chaque lot est un travail complet qui merite son propre cycle.
+
+---
+
+## Input utilisateur
+
+$ARGUMENTS

--- a/skills/audit-conformity/reference.md
+++ b/skills/audit-conformity/reference.md
@@ -1,0 +1,150 @@
+# Audit de conformite — grille, protocoles des sub-agents, formats
+
+Les sections « Protocole » sont chargees par les **sub-agents** (le skill leur passe le chemin de ce fichier dans leur prompt). Les sections « Extraction de la grille », « Format du rapport » et « Plan de remediation » sont pour le contexte principal.
+
+## Extraction de la grille
+
+Une regle est **atomique** quand un auditeur peut y repondre par oui ou non en regardant un fichier, sans interpreter. Tout ce qui demande un jugement se decoupe jusqu'a ce que ce soit vrai, ou sort de la grille.
+
+Decoupage :
+
+- Une phrase du document contenant « et », « sauf », « sauf si » porte presque toujours **plusieurs** regles — separe-les
+- Une regle qui commence par « bien », « proprement », « au mieux » n'est pas verifiable en l'etat : soit on la traduit en critere observable, soit elle rejoint les intentions
+- Une regle avec exception explicite garde son exception dans son enonce — sinon les auditeurs remonteront les exceptions comme des violations
+
+Chaque regle porte trois choses : son **enonce** (imperatif, une phrase), sa **portee** (quels fichiers elle concerne — `tous`, une extension, un repertoire), et sa **citation source** (la phrase du document dont elle vient, pour que l'arbitrage puisse remonter au texte).
+
+```
+| # | Regle | Portee | Source |
+|---|---|---|---|
+| R1 | Chaque skill est un repertoire `nom/SKILL.md` avec frontmatter | `skills/**` | « Chaque skill est un repertoire… » |
+```
+
+Sous la grille, liste a part les **intentions non verifiables** — ce que le document dit mais qu'aucun auditeur ne peut trancher (« rester concis », « penser au lecteur »). Ne les jette pas silencieusement : leur presence dit a l'utilisateur ce que l'audit ne couvrira pas, et c'est parfois le signal que le document merite d'etre precise.
+
+---
+
+## Protocole de l'auditeur
+
+Tu audites une zone de code contre une grille de regles. Tu ne corriges rien, tu ne proposes pas de refactor, tu ne donnes pas ton avis sur le code.
+
+**Ta seule question, pour chaque regle et chaque fichier de ta zone : est-elle respectee ?**
+
+Methode :
+
+1. Lis chaque fichier de ta zone via Read — **en entier**. Un audit sur des extraits produit des faux positifs (le code conforme est souvent trois lignes plus bas)
+2. Pour chaque regle dont la portee couvre le fichier, cherche activement la **contre-preuve**, pas la confirmation
+3. Toute violation exige une preuve `chemin/fichier.ext:ligne` et la citation exacte du code fautif. **Sans preuve localisee, la violation n'existe pas** — ne la remonte pas
+
+Pour chaque violation :
+
+- **regle** : le numero (`R3`)
+- **fichier** : `chemin:ligne`
+- **preuve** : la ligne ou le fragment fautif, cite tel quel
+- **ecart** : en quoi ce code contredit l'enonce de la regle — une phrase, sans jargon
+- **severite** : BLOQUANT (la regle est violee frontalement, consequence reelle) / AVERTISSEMENT (violation partielle ou contournement) / SUGGESTION (respect formel mais pas de l'esprit)
+- **confiance** : HAUTE (le texte de la regle et le code sont sans ambiguite) / MOYENNE / BASSE (la regle demande une interpretation pour trancher)
+
+Rends aussi, pour **chaque** regle de la grille, un verdict de zone : `conforme`, `viole` (avec N occurrences), ou `sans objet` (aucun fichier de ta zone n'entre dans sa portee). Une regle omise du verdict sera traitee comme non evaluee et relancera un audit — ne saute aucune ligne de la grille.
+
+Ce que tu ne fais **pas** : signaler des problemes que la grille ne couvre pas, meme s'ils sont reels (bugs, style, perf). Ce n'est pas une review de code. Un rapport qui deborde de la grille est un rapport a refaire.
+
+Zone entierement conforme = resultat valide et frequent. Ne remplis jamais pour justifier ton passage.
+
+---
+
+## Protocole du refutateur
+
+On te donne des violations remontees par un auditeur. **Ton role est de les detruire.** Tu n'es pas la pour confirmer : un constat qui survit a une tentative honnete de demolition vaut quelque chose, un constat jamais attaque ne vaut rien.
+
+Pour chaque violation, ouvre le fichier via Read, lis-le en entier, et cherche laquelle de ces sorties s'applique :
+
+- **faux positif** — le code respecte en fait la regle ; l'auditeur a mal lu, ou la conformite est ailleurs dans le fichier
+- **exception legitime** — la regle prevoit ce cas, ou le contexte (test, script generE, code legacy explicitement isole, compatibilite) le sort de sa portee
+- **regle mal interpretee** — l'auditeur a applique un enonce plus large que le document ne le dit ; cite la phrase source pour le montrer
+- **regle mauvaise** — le code a raison et le document a tort : la regle est obsolete, contredite par une autre partie du document, ou impossible a tenir. Sortie rare, mais c'est la plus precieuse : elle corrige la loi au lieu du prevenu
+- **confirme** — aucune des sorties ci-dessus ne tient apres verification
+
+**En cas de doute, le defaut est `refute`.** Un faux positif qui remonte jusqu'a l'arbitrage humain coute plus cher qu'une violation ratee : il fait perdre la confiance dans tout le rapport.
+
+Rends pour chaque violation : son identifiant, le verdict parmi les cinq ci-dessus, et **une phrase** de motif avec sa preuve (`fichier:ligne` ou citation du document).
+
+---
+
+## Protocole du critique
+
+On te donne la grille de regles, la carte des zones auditees et les rapports agreges. Tu ne lis pas le code pour trouver des violations : tu cherches ce que l'audit **n'a pas vu**.
+
+Quatre angles :
+
+1. **Regles jamais evaluees** — une regle declaree `sans objet` par toutes les zones alors que sa portee couvre des fichiers reellement presents. Signal quasi certain d'un trou
+2. **Zones survolees** — une zone qui rend zero violation sur toutes les regles alors que les autres en rendent, ou dont le rapport ne cite aucun fichier precis
+3. **Faux negatifs probables** — un endroit du projet ou la regle est structurellement difficile a tenir (code ancien, module a part, fichiers generes, points d'entree exotiques) et qu'aucun auditeur ne mentionne
+4. **Perimetre manquant** — des fichiers concernes par la grille qui n'appartiennent a aucune zone : extensions oubliees, repertoires exclus a tort, configuration, scripts, CI
+
+Rends une liste de **trous** : pour chacun, ce qui n'a pas ete couvert, pourquoi tu le penses, et la cible exacte a re-auditer (fichiers ou glob + numeros de regles). Si tu ne trouves pas de trou credible, dis-le en une ligne — inventer un doute pour paraitre utile fait relancer des agents pour rien.
+
+---
+
+## Format du rapport
+
+Fichier `.claude/audits/audit-<slug>.md` :
+
+```markdown
+# Audit de conformite — <document de reference>
+
+Perimetre : N fichiers · G zones · R regles · <date>
+
+## Verdict par regle
+
+| # | Regle | Verdict | Violations |
+|---|---|---|---|
+| R1 | <enonce court> | ✅ conforme | — |
+| R2 | <enonce court> | ❌ viole | 3 (1 bloquant) |
+| R3 | <enonce court> | — sans objet | — |
+
+## Violations confirmees
+
+### R2 — <enonce>
+
+- `src/auth/session.ts:41` — BLOQUANT · <ecart en une phrase>
+  > <ligne fautive citee>
+
+## Constats refutes
+
+| Regle | Fichier | Motif |
+|---|---|---|
+| R5 | `src/legacy/pdf.ts:12` | Exception legitime : module isole, exclu par la regle |
+
+## Ecarts acceptes
+
+| Regle | Fichier | Raison (decidee le <date>) |
+|---|---|---|
+
+## Non couvert
+
+- <intentions non verifiables de la grille>
+- <trous signales par le critique et non resolus>
+```
+
+La section « Constats refutes » n'est pas du remplissage : sans elle, le prochain audit remontera les memes faux positifs et les fera rearbitrer.
+
+## Plan de remediation
+
+Un lot est un travail **complet et livrable seul** : il ne laisse pas le projet a moitie conforme a une regle.
+
+```markdown
+## Lot 1 — <intitule> · <route>
+
+- Regles : R2, R7
+- Fichiers : N (`src/auth/`)
+- Severite max : BLOQUANT
+- Depend de : —
+```
+
+Regles de decoupage :
+
+- **Grouper par regle** quand la correction est mecanique et repetee (meme geste sur N fichiers) — un seul lot, une seule relecture
+- **Grouper par zone** quand la correction demande de comprendre le module — sinon le meme fichier est repris dans trois lots differents, avec les conflits qui vont avec
+- Ordonner par severite, puis par dependance : un lot qui deplace des fichiers passe avant celui qui les modifie
+- Un lot qui touche plus de ~15 fichiers se redecoupe : il ne sera pas relisible

--- a/skills/pipe-code/SKILL.md
+++ b/skills/pipe-code/SKILL.md
@@ -27,7 +27,7 @@ Suis le plan, guide par les tests :
 
 - **Les tests valides sont le contrat.** Interdiction de les modifier pour les faire passer. Si un test semble faux, contradictoire ou impossible a satisfaire, stoppe et signale-le — c'est une decision humaine.
 - Boucle : coder → lancer les tests (commande de `workflow-config`) → corriger. L'implementation est terminee quand **tous** les tests passent — les nouveaux et les existants.
-- **Commits au fil de l'eau, uniquement par changesets propres.** Tu peux committer quand une unite logique est terminee et que les tests qui la couvrent passent — chaque commit suit `git-conventions` (utilise Read pour le charger) : titre limpide, body detaille, c'est de la doc technique. Ce qui ne forme pas encore une unite coherente reste dans le working tree — `/pipe-commit` decoupera le reste en fin de cycle. Jamais de commit fourre-tout ou "wip".
+- **Commits au fil de l'eau, uniquement par changesets propres.** Tu peux committer quand une unite logique est terminee et que les tests qui la couvrent passent — chaque commit suit les conventions de `${CLAUDE_SKILL_DIR}/../git-conventions/SKILL.md` (utilise Read pour le charger) : titre limpide, body detaille, c'est de la doc technique. Ce qui ne forme pas encore une unite coherente reste dans le working tree — `/pipe-commit` decoupera le reste en fin de cycle. Jamais de commit fourre-tout ou "wip".
 - Respecte les conventions de `workflow-config` (stack, architecture, nommage). Pas de verification de style manuelle — c'est le role des hooks PostToolUse.
 
 Si une etape revele un probleme non anticipe dans le plan (fichier manquant, dependance absente, incoherence), **stoppe et signale-le** avant de continuer :


### PR DESCRIPTION
## Version cible

`v1.7.0`

## CHANGELOG

### Added

- Nouveau skill `/audit-conformity` : auditer la conformité du code à un document de référence (spec, règle, skill, `CLAUDE.md`) et planifier la remédiation (#59)

### Fixed

- Le marketplace pointe désormais sur le dépôt réellement publié : `/plugin install` et `/plugin update` installent bien ce plugin (#59)
- `/pipe-code` charge à nouveau les conventions git depuis un plugin installé, et non plus seulement depuis le dépôt source (#59)

## PRs incluses

- #59 [Feature] Skill audit-conformity : auditer le code contre un document de reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
